### PR TITLE
Add AVI splitting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ Turns mp3 audio compression on/off, 0 by default.
 Sets mp3 compression's bitrate, 128 by default.
 Only works if `capture_mp3` is 1 (trivial).
 
+### `capture_avi_split`
+
+Set this to the number of megabytes at which to split captured video into more
+than one AVI file. The used video capture module has a problem with files
+getting corrupted when reaching a size of over 2 gigabytes, so splitting them
+into smaller files is a good idea to avoid this corruption. Default is
+1900 megabytes. Setting to 0 disables splitting.
+
 ### `gl_externaltextures_world` and `gl_externaltextures_bmodels`
 
 Load external textures when set to "1".

--- a/trunk/movie_avi.h
+++ b/trunk/movie_avi.h
@@ -25,3 +25,4 @@ qboolean Capture_Open (char *filename);
 void Capture_WriteVideo (byte *pixel_buffer);
 void Capture_WriteAudio (int samples, byte *sample_buffer);
 void Capture_Close (void);
+LONG Capture_GetNumWrittenBytes (void);


### PR DESCRIPTION
Add feature to split video capture into separate AVI files to avoid 2GB file size limit. Seems to be working quite well for a while now.