### PR TITLE
Fix long restart times in coop play

### DIFF
--- a/trunk/net_main.c
+++ b/trunk/net_main.c
@@ -781,9 +781,7 @@ int NET_SendToAll (sizebuf_t *data, int blocktime)
 
 	for (i = 0, host_client = svs.clients ; i < svs.maxclients ; i++, host_client++)
 	{
-		if (!host_client->netconnection)
-			continue;
-		if (host_client->active)
+		if (host_client->netconnection && host_client->active)
 		{
 			if (host_client->netconnection->driver == 0)
 			{


### PR DESCRIPTION
Some undefined behaviour in NET_SendToAll caused reloads to occasionally
take 5 seconds (the given blocktime) for no reason. This was caused by
checking for net messages on unconnected slots, as the state arrays were
not initialised properly. Applying the same fix here as in other source
ports, see for example
https://github.com/luaman/qforge-1/commit/d4ae231f34ef157f549e181f3159799efffcd645
or the QuakeSpasm source code.