### PR TITLE
Fix cl_smartjump 1 crashing clients in coop

### DIFF
--- a/trunk/cl_input.c
+++ b/trunk/cl_input.c
@@ -163,7 +163,7 @@ void IN_UseUp (void) {KeyUp(&in_use);}
 void IN_JumpDown (void)
 {
 	if (cls.state == ca_connected && cl_smartjump.value && cl.stats[STAT_HEALTH] > 0 && 
-	    !cls.demoplayback && sv_player->v.waterlevel >= 2 && !(in_forward.state & 1))
+	    !cls.demoplayback && cl.inwater && !(in_forward.state & 1))
 		KeyDown (&in_up);
 	else
 		KeyDown (&in_jump);


### PR DESCRIPTION
The check for if the player is in water is done using sv_player, which
is null if only connected as client. It only works for the host.
Instead, cl.inwater can be used, as it is set to the exact condition
waterlevel >= 2 in SV_WriteClientdataToMessage. It should therefore be
equivalent for hosts, and now additionally work properly for clients.