### PR TITLE
Fix size of buffer for KeepaliveMessage

### DIFF
--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -246,13 +246,14 @@ When the client is taking a long time to load stuff, send keepalive messages
 so the server doesn't disconnect.
 ==================
 */
+static byte net_olddata[NET_MAXMESSAGE];
 void CL_KeepaliveMessage (void)
 {
 	float		time;
 	static float lastmsg;
 	int			ret;
 	sizebuf_t	old;
-	byte		olddata[8192];
+	byte		*olddata;
 	
 	if (sv.active)
 		return;		// no need if server is local
@@ -260,6 +261,7 @@ void CL_KeepaliveMessage (void)
 		return;
 
 // read messages from server, should just be nops
+	olddata = net_olddata;
 	old = net_message;
 	memcpy (olddata, net_message.data, net_message.cursize);
 


### PR DESCRIPTION
Since 84d490f6 the NET_MAXMESSAGE is larger than the size of the olddata
array for temporary storage of the message data. This can cause memory
access violations and make clients drop from a server. Happens for
example when a client uses the say command while the server issues a map
restart.

This the size of the array for temporary storage to be NET_MAXMESSAGE
directly. Also move it into static storage, as it became somewhat large
for the stack now (Visual Studio warns about it). Solution is the same
as in QuakeSpasm.