### PR TITLE
Improvements for connection times to servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,15 @@ However, the search takes a significant amount of time. So disabling it can
 greatly speedup the time it takes to connect to a server by IP address.
 "1" by default. Set to "0" to try to speedup connecting by IP address.
 
+### `net_getdomainname`
+
+Allows to enable or disable trying to find domain names for IP addresses using
+DNS lookups. These can find domain names like nl2.badplace.eu from its IP
+address. However, on Windows this lookup seems to take a long time. Disabling it
+can therefore speed up connecting to a server significantly. As there will
+barely be any usecase for the domain names, it is "0" by default. Set to "1" to
+restore the original Quake behaviour with the lookups enabled.
+
 ## New commands
 
 ### `cmdlist`

--- a/README.md
+++ b/README.md
@@ -525,6 +525,14 @@ default.
 Set texture filtering mode for sky textures. Valid modes: `GL_LINEAR` and
 `GL_NEAREST`, `GL_LINEAR` by default.
 
+### `net_connectsearch`
+
+Allows to enable or disable the search for hosts on use of the `connect`
+command. It allows connecting by the server's hostname instead of by IP address.
+However, the search takes a significant amount of time. So disabling it can
+greatly speedup the time it takes to connect to a server by IP address.
+"1" by default. Set to "0" to try to speedup connecting by IP address.
+
 ## New commands
 
 ### `cmdlist`

--- a/trunk/net_main.c
+++ b/trunk/net_main.c
@@ -63,6 +63,7 @@ int unreliableMessagesSent = 0;
 int unreliableMessagesReceived = 0;
 
 cvar_t	net_messagetimeout = {"net_messagetimeout", "300"};
+cvar_t	net_connectsearch = {"net_connectsearch", "1"};
 cvar_t	net_connecttimeout = {"net_connecttimeout", "10"};	// joe: qkick/qflood protection from ProQuake
 cvar_t	hostname = {"hostname", "UNNAMED"};
 cvar_t	cl_password = {"cl_password", ""};		// joe: password protection from ProQuake
@@ -409,11 +410,14 @@ qsocket_t *NET_Connect (char *host)
 		}
 	}
 
-	slistSilent = host ? true : false;
-	NET_Slist_f ();
+	if (net_connectsearch.value || !host)
+	{
+		slistSilent = host ? true : false;
+		NET_Slist_f ();
 
-	while (slistInProgress)
-		NET_Poll ();
+		while (slistInProgress)
+			NET_Poll ();
+	}
 
 	if (!host)
 	{
@@ -887,6 +891,7 @@ void NET_Init (void)
 	SZ_Alloc (&net_message, NET_MAXMESSAGE);
 
 	Cvar_Register (&net_messagetimeout);
+	Cvar_Register (&net_connectsearch);
 	Cvar_Register (&net_connecttimeout);	// joe: qkick/qflood protection from ProQuake
 	Cvar_Register (&hostname);
 	Cvar_Register (&cl_password);		// joe: password protection from ProQuake

--- a/trunk/net_main.c
+++ b/trunk/net_main.c
@@ -65,6 +65,7 @@ int unreliableMessagesReceived = 0;
 cvar_t	net_messagetimeout = {"net_messagetimeout", "300"};
 cvar_t	net_connectsearch = {"net_connectsearch", "1"};
 cvar_t	net_connecttimeout = {"net_connecttimeout", "10"};	// joe: qkick/qflood protection from ProQuake
+cvar_t	net_getdomainname = {"net_getdomainname", "0"};
 cvar_t	hostname = {"hostname", "UNNAMED"};
 cvar_t	cl_password = {"cl_password", ""};		// joe: password protection from ProQuake
 cvar_t	rcon_password = {"rcon_password", ""};		// joe: rcon password from ProQuake
@@ -914,6 +915,7 @@ void NET_Init (void)
 	Cvar_Register (&net_messagetimeout);
 	Cvar_Register (&net_connectsearch);
 	Cvar_Register (&net_connecttimeout);	// joe: qkick/qflood protection from ProQuake
+	Cvar_Register (&net_getdomainname);
 	Cvar_Register (&hostname);
 	Cvar_Register (&cl_password);		// joe: password protection from ProQuake
 	Cvar_Register (&rcon_password);		// joe: rcon password from ProQuake

--- a/trunk/net_wins.c
+++ b/trunk/net_wins.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "winquake.h"
 
 extern cvar_t hostname;
+extern cvar_t net_getdomainname;
 
 #define MAXHOSTNAMELEN	256
 
@@ -494,11 +495,13 @@ int WINS_GetNameFromAddr (struct qsockaddr *addr, char *name)
 {
 	struct	hostent	*hostentry;
 
-	hostentry = pgethostbyaddr ((char *)&((struct sockaddr_in *)addr)->sin_addr, sizeof(struct in_addr), AF_INET);
-	if (hostentry)
-	{
-		Q_strncpy (name, (char *)hostentry->h_name, NET_NAMELEN - 1);
-		return 0;
+	if (net_getdomainname.value) {
+		hostentry = pgethostbyaddr ((char *)&((struct sockaddr_in *)addr)->sin_addr, sizeof(struct in_addr), AF_INET);
+		if (hostentry)
+		{
+			Q_strncpy (name, (char *)hostentry->h_name, NET_NAMELEN - 1);
+			return 0;
+		}
 	}
 
 	Q_strcpy (name, WINS_AddrToString (addr));


### PR DESCRIPTION
Add two cvars `net_connectsearch` and `net_getdomainname` that allow disabling two barely used features that can seriously slowdown the process of connecting to a server with the `connect` command. Also checking the hostcache for IP address now in addition to the hostname to allow faster connection if in cache.

These improvements are especially useful for coop speedrunning when there are more players than spawnpoints, because that means that players need to connect to the server over and over on each reset.