### PR TITLE
Only pause time-based viewangle calculations 

### DIFF
--- a/trunk/sv_main.c
+++ b/trunk/sv_main.c
@@ -283,6 +283,10 @@ void SV_SendServerinfo (client_t *client)
 	MSG_WriteByte (&client->message, svc_setview);
 	MSG_WriteShort (&client->message, NUM_FOR_EDICT(client->edict));
 
+// Sphere -- if server is paused we also have to inform the client about that
+	MSG_WriteByte (&client->message, svc_setpause);
+	MSG_WriteByte (&client->message, sv.paused);
+
 	MSG_WriteByte (&client->message, svc_signonnum);
 	MSG_WriteByte (&client->message, 1);
 

--- a/trunk/view.c
+++ b/trunk/view.c
@@ -210,7 +210,7 @@ void V_DriftPitch (void)
 	{
 		if (fabs(cl.cmd.forwardmove) < cl_forwardspeed.value)
 			cl.driftmove = 0;
-		else
+		else if (!cl.paused)
 			cl.driftmove += host_frametime;
 
 		if (cl.driftmove > v_centermove.value)
@@ -228,7 +228,8 @@ void V_DriftPitch (void)
 	}
 
 	move = host_frametime * cl.pitchvel;
-	cl.pitchvel += host_frametime * v_centerspeed.value;
+	if (!cl.paused)
+		cl.pitchvel += host_frametime * v_centerspeed.value;
 
 //Con_Printf ("move: %f (%f)\n", move, host_frametime);
 
@@ -1050,7 +1051,8 @@ void V_CalcViewRoll (void)
 	{
 		r_refdef.viewangles[ROLL] += v_dmg_time / v_kicktime.value * v_dmg_roll;
 		r_refdef.viewangles[PITCH] += v_dmg_time / v_kicktime.value * v_dmg_pitch;
-		v_dmg_time -= host_frametime;
+		if (!cl.paused)
+			v_dmg_time -= host_frametime;
 	}
 }
 
@@ -1557,8 +1559,7 @@ void V_RenderView (void)
 	}
 	else
 	{
-		if (!cl.paused)
-			V_CalcRefdef ();
+		V_CalcRefdef ();
 	}
 
 	R_PushDlights ();


### PR DESCRIPTION
Computation of viewangle stuff is completely omitted when the game is paused. I assume the idea here was that the player should not be able to look around while the game is paused anyways? However, mouse inputs are still taken and applied. That means that if you move your mouse while the game is paused, you will suddenly look somewhere completely different once you unpause. This is especially notable in coop play where you always pause on the start of a map.

To fix this, we now do all the viewangle stuff, even when paused. Most things worked exactly as intended still. Seemingly only those parts that do some internal timing by updating a timer on each call have to be skipped when paused now.

This also makes the start of coop runs for clients much more intuitive. Before, the game was instantly paused, so they would not get a viewangle update until the game was unpaused. So they kept their previous viewangle from before the map restart and didnt see where they would be spawning. Now they always get viewangle updates, so this is fixed too.