### PR TITLE
Fix memory access violation in r_viewleaf2

### DIFF
--- a/trunk/gl_model.c
+++ b/trunk/gl_model.c
@@ -155,7 +155,11 @@ byte *Mod_DecompressVis (byte *in, model_t *model)
 	row = (model->numleafs + 7) >> 3;
 	if (mod_decompressed == NULL || row > mod_decompressed_capacity)
 	{
-		mod_decompressed_capacity = row;
+		// Sphere -- we have to allocate in multiples of four bytes, because in
+		// R_MarkLeaves, the result of this function will be iterated over in
+		// increments of sizeof(unsigned) which is 4 on the platforms that
+		// are targeted.
+		mod_decompressed_capacity = NextMultipleOfFour(row);
 		mod_decompressed = (byte *)Q_realloc(mod_decompressed, mod_decompressed_capacity);
 		if (!mod_decompressed)
 			Sys_Error("Mod_DecompressVis: realloc() failed on %d bytes", mod_decompressed_capacity);

--- a/trunk/gl_rsurf.c
+++ b/trunk/gl_rsurf.c
@@ -1348,7 +1348,11 @@ void R_MarkLeaves (void)
 			count = (cl.worldmodel->numleafs + 7) >> 3;
 			if (solid == NULL || count > solid_capacity)
 			{
-				solid_capacity = count;
+				// Sphere -- we have to allocate in multiples of four bytes,
+				// because a few lines below we will iterate over this in
+				// increments of sizeof(unsigned) which is 4 on the platforms
+				// that are targeted.
+				solid_capacity = NextMultipleOfFour(count);
 				solid = (byte *)Q_realloc(solid, solid_capacity);
 				if (!solid)
 					Sys_Error("R_MarkLeaves: realloc() failed on %d bytes", solid_capacity);

--- a/trunk/mathlib.c
+++ b/trunk/mathlib.c
@@ -403,6 +403,18 @@ void SortIntArrayAscending(int *elements, int num_elem)
 	qsort(elements, num_elem, sizeof(int), compare_int);
 }
 
+/*
+===================
+NextMultipleOfFour
+
+Returns the multiple of 4 that is greater or equal to the given integer value.
+====================
+*/
+int NextMultipleOfFour(int value)
+{
+	return ((value + 3) / 4) * 4;
+}
+
 #if !id386
 
 /*

--- a/trunk/mathlib.h
+++ b/trunk/mathlib.h
@@ -147,6 +147,7 @@ void FloorDivMod (double numer, double denom, int *quotient, int *rem);
 fixed16_t Invert24To16 (fixed16_t val);
 int GreatestCommonDivisor (int i1, int i2);
 void SortIntArrayAscending(int *elements, int num_elem);
+int NextMultipleOfFour(int value);
 
 void vectoangles (vec3_t vec, vec3_t ang);
 void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up);


### PR DESCRIPTION
Since 8b4b03a2 there are no oversized arrays with static sizes for vis data anymore. Instead they are allocated dynamically for the required size. Unfortunately, in https://github.com/j0zzz/JoeQuake/blob/e538f70a3f37412bfae700a3f8b897311caf1850/trunk/gl_rsurf.c#L1361 that data is iterated over in increments of 4 bytes, which causes buffer overruns if the dynamically allocated size is not a multiple of 4. This makes sure to always allocate a multiple of 4.

Alternatively one could get rid of that iteration in increments of 4 instead i guess. Seems a bit like evil premature optimization to be
honest, so might be the better call.