### PR TITLE
Fix pause plaque showing when loading a save

### DIFF
--- a/trunk/sv_main.c
+++ b/trunk/sv_main.c
@@ -285,9 +285,11 @@ void SV_SendServerinfo (client_t *client)
 	MSG_WriteByte (&client->message, svc_setview);
 	MSG_WriteShort (&client->message, NUM_FOR_EDICT(client->edict));
 
-// Sphere -- if server is paused we also have to inform the client about that
+// Sphere -- if server is paused we also have to inform the client about that,
+// but only if it was issued by a client through Host_Pause_f (i.e. both
+// sv.paused and cl.paused are true)
 	MSG_WriteByte (&client->message, svc_setpause);
-	MSG_WriteByte (&client->message, sv.paused);
+	MSG_WriteByte (&client->message, sv.paused && cl.paused);
 
 	MSG_WriteByte (&client->message, svc_signonnum);
 	MSG_WriteByte (&client->message, 1);


### PR DESCRIPTION
This bug was introduced in 3dbeb8ea. Wanted to make it so that a client who connects to a paused server will get the pause plaque to know what's going on. Unfortunately the solution in that commit also made it pause on loading a save, which was not intended of course. To fix that we now send the pause state as true, only if the pause was actually issued by the host via Host_Pause_f. Determining that by requiring that cl.paused and sv.paused are both true instead of only sv.paused.

Cleanest solution I could come up with. Did a bunch of testing, seems good in all cases now.