### PR TITLE
Fix coop client freeze on server map restart

### DIFF
--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -259,6 +259,13 @@ void CL_KeepaliveMessage (void)
 		return;		// no need if server is local
 	if (cls.demoplayback)
 		return;
+	if (!NET_CanSendMessage(cls.netcon))
+		// Sphere -- if we cannot send another message yet, calling
+		// NET_SendMessage below is not allowed and would break things. So we
+		// skip sending a keepalive message for now. Maybe on the next call we
+		// will be allowed to send one again, or maybe we are just loading stuff
+		// so quickly that we dont need a keepalive message.
+		return;
 
 // read messages from server, should just be nops
 	olddata = net_olddata;


### PR DESCRIPTION
If a client uses "say" almost in the same instant that the host restarts the map, that client would often fail to reconnect to the server. The problem is that the keepalive message is sent using `NET_SendMessage` without checking whether a message may be send with `NET_CanSendMessage`. So if a keepalive message is sent before the acknowledge message from the server is received, the datagram system trips up. The `sendSequence` and `ackSequence` counters go out of sync and nothing works anymore.

To fix this, we just skip sending a keepalive message if we cant send a message. If stuff is loaded faster than receiving the acknowledge message we probably dont need a keepalive anyways. If a message can be send in a later call, we can still send a keepalive message then.