### PR TITLE
Fix qdqstats replacement messages for coop

### DIFF
--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -341,10 +341,14 @@ void CL_SignonReply (void)
 			else
 				Cmd_ExecuteString("record\n", src_command);
 		}
-		if (!pr_qdqstats && !cls.demoplayback)
+		if (!pr_qdqstats && !cls.demoplayback && sv.active)
 		{
+			// Sphere --- calling SV_ from CL_ here is probably not the best,
+			// but at least we check for sv.active. We need the broadcast so
+			// that the message appears in recorded demos and also gets sent to
+			// clients during coop play.
 			int current_skill = bound(0, skill.value, 3);
-			Con_Printf("Playing on %s skill\n", skill_modes[current_skill]);
+			SV_BroadcastPrintf("Playing on %s skill\n", skill_modes[current_skill]);
 		}
 		break;
 	}

--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -1162,19 +1162,23 @@ void PrintFinishTime()
 	cls.marathon_time += cl.completed_time;
 	cls.marathon_level++;
 
-	if (!pr_qdqstats && !cls.demoplayback)
+	if (!pr_qdqstats && !cls.demoplayback && sv.active)
 	{
+		// Sphere --- calling SV_ from CL_ here is probably not the best, but at
+		// least we check for sv.active. We need the broadcast so that the time
+		// messages appear in recorded demos and also get sent to clients
+		// during coop play.
 		timestring = GetPrintedTime(cl.completed_time);
-		Con_Printf("\nexact time was %s\n", timestring);
+		SV_BroadcastPrintf("\nexact time was %s\n", timestring);
 
 		if (cls.marathon_level > 1)
 		{
-			Con_Printf("level %i in the sequence\n", cls.marathon_level);
+			SV_BroadcastPrintf("level %i in the sequence\n", cls.marathon_level);
 			timestring = GetPrintedTime(cls.marathon_time);
-			Con_Printf("total time is %s\n", timestring);
+			SV_BroadcastPrintf("total time is %s\n", timestring);
 		}
 
-		Con_Printf("\n");
+		SV_BroadcastPrintf("\n");
 	}
 }
 


### PR DESCRIPTION
During coop play, only the server should issue the skill and time messages to simulate QdQstats if it isnt available. So we make sure to only print if `sv.active` is `true`. In order for the clients to receive those messages, we also have to change the used `Con_Printf` to
`SV_BroadcastPrintf`. That also makes the messages be stored in demos, which is actually desirable too, as that's how QdQstats behaves.