### PR TITLE
Add new achievement server message for remaster

### DIFF
--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -1496,6 +1496,12 @@ void CL_ParseServerMessage (void)
 			CL_ParseStaticSound(2);
 			break;
 			//johnfitz
+
+		case svc_achievement:
+			// Sphere -- The achievements from Quake Remaster (2021) seem to be just strings.
+			// We don't really care about them, so let's just ignore them.
+			(void)MSG_ReadString();
+			break;
 		}
 	}
 }

--- a/trunk/protocol.h
+++ b/trunk/protocol.h
@@ -206,6 +206,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	svc_spawnstaticsound2	44	// [coord3] [short] samp [byte] vol [byte] aten
 //johnfitz
 
+//Sphere -- new server message for Quake Remaster (2021)
+#define svc_achievement	52
+
 // client to server
 #define	clc_bad			0
 #define	clc_nop 		1


### PR DESCRIPTION
Remaster seems to have a new server message to track achievements. The message is just a string that we ignore, at least for now.