### PR TITLE
Fix size of key_lines in extern declaration

### DIFF
--- a/trunk/cmd.c
+++ b/trunk/cmd.c
@@ -708,7 +708,7 @@ static void CompareParams (void)
 }
 
 static void PrintEntries (void);
-extern char key_lines[32][MAXCMDLINE];
+extern char key_lines[64][MAXCMDLINE];
 extern int	edit_line;
 extern int	key_linepos;
 

--- a/trunk/console.c
+++ b/trunk/console.c
@@ -58,7 +58,7 @@ int		con_notifylines;		// scan lines to clear for notify lines
 
 FILE	*qconsole_log;
 
-extern	char key_lines[32][MAXCMDLINE];
+extern	char key_lines[64][MAXCMDLINE];
 extern	int	edit_line;
 extern	int	key_linepos;
 extern	int	key_insert;


### PR DESCRIPTION
`key_lines` is defined with size 64 in the first dimension, not 32, see https://github.com/j0zzz/JoeQuake/blob/8c1c33f2bfdf7ca8dae37605c90fd5f1077b2707/trunk/keys.c#L30