### PR TITLE
Fix multiple definition of com_searchpaths

### DIFF
--- a/trunk/common.c
+++ b/trunk/common.c
@@ -37,6 +37,8 @@ static char *safeargvs[NUM_SAFE_ARGVS] = {
 	"-dibonly"
 };
 
+searchpath_t	*com_searchpaths;
+
 cvar_t  registered = {"registered", "0"};
 cvar_t  cmdline = {"cmdline", "0", CVAR_SERVER};
 

--- a/trunk/common.h
+++ b/trunk/common.h
@@ -254,7 +254,7 @@ typedef struct searchpath_s
 	struct searchpath_s *next;
 } searchpath_t;
 
-searchpath_t	*com_searchpaths;
+extern	searchpath_t	*com_searchpaths;
 
 void COM_ForceExtension (char *path, char *extension);
 int COM_FileLength (FILE *f);


### PR DESCRIPTION
Definition of `com_searchpaths` in header causes it to be redefined in every translation unit that includes `common.h`. Instead define it in the source file and provide an extern declaration in the header. Not sure why MSVC even accepts this, gcc and clang do not.