### PR TITLE
Add missing header includes

### DIFF
--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -34,6 +34,7 @@ qboolean	start_of_demo = false;
 #ifdef _WIN32
 static	HANDLE	hDZipProcess = NULL;
 #else
+#include <errno.h>
 //#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/trunk/fmod.c
+++ b/trunk/fmod.c
@@ -23,6 +23,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "fmod_errors.h"
 #include "quakedef.h"
 
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
 static FMUSIC_MODULE	*mod = NULL;
 static FSOUND_STREAM	*stream = NULL;
 

--- a/trunk/gl_model.h
+++ b/trunk/gl_model.h
@@ -24,6 +24,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "modelgen.h"
 #include "spritegn.h"
 
+#include <stdint.h>
+
 /*
 
 d*_t structures are on-disk representations

--- a/trunk/image.c
+++ b/trunk/image.c
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "jpeglib.h"
 #endif
 #endif
+#include "zlib.h"
 
 #define	IMAGE_MAX_DIMENSIONS	8192
 


### PR DESCRIPTION
`errno.h` for `errno`, `dlfcn.h` for `dlopen` and co., `stdint.h` for `intptr_t` and `zlib.h` for the `Z_` constants. Some are Linux only, but others apply for Windows too. Suppose it worked only by chance on MSVC.