### PR TITLE
Fix multiple definition of sb_lines

### DIFF
--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -116,8 +116,6 @@ int		scr_fullupdate;
 int		clearconsole;
 int		clearnotify;
 
-int		sb_lines;
-
 viddef_t	vid;				// global video state
 
 vrect_t		scr_vrect;


### PR DESCRIPTION
`sb_lines` is already defined here https://github.com/j0zzz/JoeQuake/blob/1191cd82c29a184894e64cc770ffb3ce8f4eb2b5/trunk/sbar.c#L49 and declared as `extern` here https://github.com/j0zzz/JoeQuake/blob/1191cd82c29a184894e64cc770ffb3ce8f4eb2b5/trunk/sbar.h#L26 so it should not be redefined here https://github.com/j0zzz/JoeQuake/blob/1191cd82c29a184894e64cc770ffb3ce8f4eb2b5/trunk/gl_screen.c#L119 just like it is not redefined in `r_screen.c`. I guess MSVC accepts it, but gcc and clang rightly do not.