### PR TITLE
Fix build on some platforms with preprocessor

### DIFF
--- a/trunk/host.c
+++ b/trunk/host.c
@@ -572,8 +572,10 @@ qboolean Host_FilterTime (double time)
 
 	if (host_framerate.value > 0 || (cls.demoplayback && cl_demospeed.value != 1))
 		frametime = MinPhysFrameTime();
+#ifdef _WIN32
 	else if (Movie_IsActive())
 		frametime = Movie_FrameTime();
+#endif
 	else
 		frametime = 1.0 / (!cl_maxfps.value ? 1000 : bound(10, cl_maxfps.value, 1000));
 

--- a/trunk/r_part.c
+++ b/trunk/r_part.c
@@ -59,6 +59,7 @@ static	int		r_numparticles;
 
 vec3_t			r_pright, r_pup, r_ppn;
 
+#ifndef GLQUAKE
 #if !id386
 
 /*
@@ -204,6 +205,7 @@ void D_DrawParticle (particle_t *pparticle)
 }
 
 #endif	// !id386
+#endif	// !defined(GLQUAKE)
 
 #ifdef GLQUAKE
 static void Classic_LoadParticleTexures (void)

--- a/trunk/zone.c
+++ b/trunk/zone.c
@@ -103,7 +103,11 @@ void *Q_strdup (const char *str)
 {
 	char	*p;
 
+#ifdef _WIN32
 	if (!(p = _strdup(str)))
+#else
+	if (!(p = strdup(str)))
+#endif
 		Sys_Error ("Not enough memory free; check disk space");
 
 	return p;


### PR DESCRIPTION
* Missing check around `Movie_IsActive` which only exists on Windows
* `D_DrawParticle` is not used if `GLQUAKE` is defined, see: https://github.com/j0zzz/JoeQuake/blob/1191cd82c29a184894e64cc770ffb3ce8f4eb2b5/trunk/r_part.c#L879-L881
* On Linux need to use the posix name without MSVC's underscore