### PR TITLE
gl_rmain.c fixes

### DIFF
--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -20,6 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // gl_rmain.c
 
 #include "quakedef.h"
+#include <stddef.h>
 
 entity_t r_worldentity;
 

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -3005,7 +3005,7 @@ void R_SetupFrame (void)
 	r_cache_thrash = false;
 }
 
-__inline void MYgluPerspective (GLdouble fovy, GLdouble aspect, GLdouble zNear, GLdouble zFar)
+void MYgluPerspective (GLdouble fovy, GLdouble aspect, GLdouble zNear, GLdouble zFar)
 {
 	GLdouble	xmin, xmax, ymin, ymax;
 


### PR DESCRIPTION
* Add missing include for `offsetof`. [According to the stadard](https://en.cppreference.com/w/c/types/offsetof), `offsetof` requires the header `stddef.h` to be included.
* Fix unresolved non-static inline function. A single definition of a non-static inline function does not seem to make sure that it will end up in the binary (see https://godbolt.org/z/3s8vhz5jz). An additional `static` seems to be required here. The even simpler fix is to just drop the `inline` and leave the decision to the compiler.