### PR TITLE
Fix using memcpy for overlapping memory

### DIFF
--- a/trunk/cmd.c
+++ b/trunk/cmd.c
@@ -165,7 +165,7 @@ void Cbuf_Execute (void)
 		{
 			i++;
 			cmd_text.cursize -= i;
-			memcpy (text, text + i, cmd_text.cursize);
+			memmove (text, text + i, cmd_text.cursize);
 		}
 
 	// execute the command line

--- a/trunk/net_dgrm.c
+++ b/trunk/net_dgrm.c
@@ -415,7 +415,7 @@ int Datagram_GetMessage (qsocket_t *sock)
 			sock->sendMessageLength -= MAX_DATAGRAM;
 			if (sock->sendMessageLength > 0)
 			{
-				memcpy (sock->sendMessage, sock->sendMessage + MAX_DATAGRAM, sock->sendMessageLength);
+				memmove (sock->sendMessage, sock->sendMessage + MAX_DATAGRAM, sock->sendMessageLength);
 				sock->sendNext = true;
 			}
 			else

--- a/trunk/net_loop.c
+++ b/trunk/net_loop.c
@@ -147,7 +147,7 @@ int Loop_GetMessage (qsocket_t *sock)
 	sock->receiveMessageLength -= length;
 
 	if (sock->receiveMessageLength)
-		memcpy (sock->receiveMessage, &sock->receiveMessage[length], sock->receiveMessageLength);
+		memmove (sock->receiveMessage, &sock->receiveMessage[length], sock->receiveMessageLength);
 
 	if (sock->driverdata && ret == 1)
 		((qsocket_t *)sock->driverdata)->canSend = true;


### PR DESCRIPTION
Some calls to `memcpy` are made with overlapping destination and source which is undefined behaviour [according to the standard](https://en.cppreference.com/w/c/string/byte/memcpy). Have to use `memmove` for those instead. Found with address sanitizer on Linux and the undefined behaviour does indeed break things there.