### PR TITLE
Fix players with quad disappearing in mg1 mappack

### DIFF
--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -1128,7 +1128,9 @@ void CL_RelinkEntities (void)
 			continue;
 
 		// nehahra support
-		if (ent->effects & EF_NODRAW)
+		// BUT: the mg1 machine mission pack uses the same value as EF_NODRAW
+		// for some kind of quad effect. So do not want to hide in that case.
+		if (ent->effects & EF_NODRAW && !machine)
 			continue;
 
 		VectorCopy(ent->origin, ent->oldorigin);


### PR DESCRIPTION
The "Dimensions of the machine" mission pack seems to use the same value as nehahras `EF_NODRAW`, but for a different effect related to carrying quad. Therefore need to make sure that entities with that value are still drawn if on the machine mission pack.

Some related changes for differently used effects were done in https://github.com/j0zzz/JoeQuake/commit/d05fc878fec0ce21a0869020e1f1aeb30d4e36e2.