### PR TITLE
Features for showing and setting spawn parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,33 @@ Usage:
 `<density>` defines the thickness of the fog.
 `<red> <green> <blue>` values define the color of the fog.
 
+### `printspawnparams [clientnum]`
+
+Prints the spawn parameters of clients on the server. If `clientnum` is given,
+prints the spawn parameters for the client with that number. If it is not given,
+prints the spawn parameters for all active clients on the server.
+
+### `setspawnparam <paramnum> <value> [clientnum]`
+
+Sets the spawn parameter with index `paramnum` to `value`. If `clientnum` is
+given, the spawn parameter of the client with that number is changed. If it is
+not given, the spawn parameter of the host is changed.
+
+### `writenextspawnparams [clientnum] [filename]`
+
+Writes a config to store the spawn parameters as they would be if the current
+map is finished as is. Can be executed to start playing the next map with those
+stored spawn parameters.
+
+If this client is not the server host, the spawn parameters of this client are
+written and assigned to the number `clientnum` (`0` if not given). If this
+client is the server host, writes spawn parameters of the client with number
+`clientnum`. If `clientnum` is not given, writes the spawn parameters for all
+active clients on the server.
+
+The name of the written config file can be given as `filename`. If not present,
+an automatic name based on current map and time is used.
+
 ## Other features
 
 ### Parameter completion

--- a/trunk/host_cmd.c
+++ b/trunk/host_cmd.c
@@ -1914,7 +1914,7 @@ static void WriteNextSpawnParamsForThisClient (FILE *f, int client_num)
 
 void Host_WriteNextSpawnParams_f(void)
 {
-	char	name[MAX_OSPATH*2], easyname[MAX_OSPATH*2] = "";
+	char	name[MAX_OSPATH*2], path[MAX_OSPATH*2];
 
 	if (cmd_source != src_command)
 		return;
@@ -1946,7 +1946,7 @@ void Host_WriteNextSpawnParams_f(void)
 		time (&ltime);
 		strftime (str, sizeof(str)-1, "%Y%m%d_%H%M%S", localtime(&ltime));
 
-		Q_snprintfz (easyname, sizeof(easyname), "%s_%s", CL_MapName(), str);
+		Q_snprintfz (name, sizeof(name), "%s_%s", CL_MapName(), str);
 	}
 	else if (argc == 3)
 	{
@@ -1955,19 +1955,17 @@ void Host_WriteNextSpawnParams_f(void)
 			Con_Printf ("Relative pathnames are not allowed\n");
 			return;
 		}
+		Q_strncpyz (name, Cmd_Argv(2), sizeof(name));
 	}
 
-	if (easyname[0])
-		Q_snprintfz (name, sizeof(name), "%s/%s", com_gamedir, easyname);
-	else
-		Q_snprintfz (name, sizeof(name), "%s/%s", com_gamedir, Cmd_Argv(2));
 	COM_ForceExtension (name, ".cfg");
+	Q_snprintfz (path, sizeof(path), "%s/%s", com_gamedir, name);
 
 	FILE* f = NULL;
-	if (!(f = fopen(name, "w")))
+	if (!(f = fopen(path, "w")))
 	{
-		COM_CreatePath(name);
-		if (!(f = fopen(name, "w")))
+		COM_CreatePath(path);
+		if (!(f = fopen(path, "w")))
 		{
 			Con_Printf("ERROR: couldn't open %s\n", name);
 			return;
@@ -1994,6 +1992,7 @@ void Host_WriteNextSpawnParams_f(void)
 			}
 		}
 	}
+	Con_Printf ("Wrote %s\n", name);
 	fclose(f);
 }
 

--- a/trunk/host_cmd.c
+++ b/trunk/host_cmd.c
@@ -1922,6 +1922,16 @@ void Host_WriteNextSpawnParams_f(void)
 		return;
 
 	const int argc = Cmd_Argc();
+	int client_num = 0;
+	if (argc > 1)
+	{
+		client_num = atoi(Cmd_Argv(1));
+		if (sv.active && (client_num < 0 || client_num >= svs.maxclients))
+		{
+			Con_Printf("Invalid client number.\n");
+			return;
+		}
+	}
 	if (argc > 3)
 	{
 		Con_Printf ("Usage: writenextspawnparams [clientnum] [filename]\n");
@@ -1966,27 +1976,17 @@ void Host_WriteNextSpawnParams_f(void)
 
 	if (!sv.active)
 	{
-		int client_num = 0;
-		if (argc > 1)
-			client_num = atoi(Cmd_Argv(1));
 		WriteNextSpawnParamsForThisClient(f, client_num);
 	}
 	else
 	{
 		if (argc > 1)
 		{
-			const int client_num = atoi(Cmd_Argv(1));
-			if (client_num < 0 || client_num >= svs.maxclients)
-			{
-				Con_Printf("Invalid client number.\n");
-				fclose(f);
-				return;
-			}
 			WriteNextSpawnParamsForServerClient(f, &svs.clients[client_num].edict->v, client_num);
 		}
 		else
 		{
-			for (int client_num = 0; client_num < svs.maxclients; ++client_num)
+			for (client_num = 0; client_num < svs.maxclients; ++client_num)
 			{
 				if (!svs.clients[client_num].active)
 					continue;

--- a/trunk/host_cmd.c
+++ b/trunk/host_cmd.c
@@ -1863,8 +1863,13 @@ static float GetActiveWeaponForQdQstatsSpawnParams (const int active_weapon)
 		case IT_LIGHTNING:
 			return 7.0f;
 		default:
-			// invalid weapon, this should not happen. Default to shotgun.
-			return 1.0f;
+			// Set default to axe. It's possible that active_weapon is 0 if we
+			// get it from cl.stats[STAT_ACTIVEWEAPON], because IT_AXE does not
+			// fit in the byte that is sent over to populate it. In that case
+			// returning the value 0.0f for axe is indeed correct. All other
+			// cases would be invalid and should not happen, but defaulting to
+			// axe for those seems like a decent idea too.
+			return 0.0f;
 	}
 }
 


### PR DESCRIPTION
To simplify saving and setting spawn parameters for working on segmented speedruns. While `qdqstats` does offer an interface to do this, it seems rather cumbersome to work with. We were especially not sure how to work with it for coop runs, i.e. how to set spawn parameters for a 2nd (or further) players. These additions aim to provide an easier to use engine-side solution.