### PR TITLE
Ghost dzip support

### DIFF
--- a/trunk/JoeQuake.vcxproj
+++ b/trunk/JoeQuake.vcxproj
@@ -25,36 +25,37 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8BAAFF94-EA92-4366-9B4F-B9E9F896CF1D}</ProjectGuid>
     <RootNamespace>joequake</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GL Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GL Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Direct3D Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Software Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Software Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>false</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -259,7 +260,7 @@
     <Link>
       <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>.\dxsdk\lib\dxguid.lib;opengl32.lib;wsock32.lib;winmm.lib;libpng.lib;libjpeg.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>.\..\..\..\..\joequake-gl.exe</OutputFile>
+      <OutputFile>release_gl\JoeQuake.exe</OutputFile>
       <Version>
       </Version>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -388,6 +389,7 @@
     <ResourceCompile Include="joequake.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="cl_dzip.c" />
     <ClCompile Include="fmod.c" />
     <ClCompile Include="ghost\demoparse.c" />
     <ClCompile Include="ghost\ghost.c" />

--- a/trunk/JoeQuake.vcxproj
+++ b/trunk/JoeQuake.vcxproj
@@ -25,37 +25,36 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8BAAFF94-EA92-4366-9B4F-B9E9F896CF1D}</ProjectGuid>
     <RootNamespace>joequake</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GL Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='GL Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Direct3D Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Software Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Software Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>false</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -260,7 +259,7 @@
     <Link>
       <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>.\dxsdk\lib\dxguid.lib;opengl32.lib;wsock32.lib;winmm.lib;libpng.lib;libjpeg.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>release_gl\JoeQuake.exe</OutputFile>
+      <OutputFile>.\..\..\..\..\joequake-gl.exe</OutputFile>
       <Version>
       </Version>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/trunk/JoeQuake.vcxproj.filters
+++ b/trunk/JoeQuake.vcxproj.filters
@@ -426,6 +426,9 @@
     <ClCompile Include="ghost\ghostparse.c">
       <Filter>Source Files\Ghost</Filter>
     </ClCompile>
+    <ClCompile Include="cl_dzip.c">
+      <Filter>Source Files\Client</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="adivtab.h">

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -502,7 +502,7 @@ static void CheckDZipCompletion (void)
 {
     dzip_status_t dzip_status;
 
-    dzip_status = Dzip_CheckCompletion(dzCtx);
+    dzip_status = Dzip_CheckCompletion(&dzCtx);
 
     switch (dzip_status) {
         case DZIP_NOT_EXTRACTING:
@@ -553,6 +553,39 @@ static void StopDZPlayback (void)
 		tempdem_name[0] = '\0';
 	}
 	dz_playback = false;
+}
+
+
+static void PlayDZDemo (void)
+{
+	const char *name;
+	dzip_status_t dzip_status;
+
+	name = Cmd_Argv(1);
+
+	if (Dzip_Extracting(&dzCtx)) {
+		Con_Printf ("Cannot unpack -- DZip is still running!\n");
+		return;
+	}
+
+	dzip_status = Dzip_StartExtract(&dzCtx, name, &cls.demofile);
+
+	switch (dzip_status) {
+		case DZIP_NO_EXIST:
+			Con_Printf ("ERROR: couldn't open %s\n", name);
+			return;
+		case DZIP_EXTRACT_SUCCESS:
+			Con_Printf ("Already extracted, playing demo\n");
+			StartPlayingOpenedDemo ();
+			return;
+		case DZIP_EXTRACT_FAIL:
+			// Error message printed by `Dzip_StartExtract`.
+			return;
+		case DZIP_EXTRACT_IN_PROGRESS:
+			Con_Printf ("\x02" "\nunpacking demo. please wait...\n\n");
+			key_dest = key_game;
+			return;
+	}
 }
 
 static void PlayDZDemo (void)

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -509,7 +509,7 @@ static void CheckDZipCompletion (void)
 {
     dzip_status_t dzip_status;
 
-    dzip_status = Dzip_CheckCompletion(&dzCtx);
+    dzip_status = DZip_CheckCompletion(&dzCtx);
 
     switch (dzip_status) {
         case DZIP_NOT_EXTRACTING:
@@ -560,7 +560,7 @@ static void PlayDZDemo (void)
 
 	name = Cmd_Argv(1);
 
-	dzip_status = Dzip_StartExtract(&dzCtx, name, &cls.demofile);
+	dzip_status = DZip_StartExtract(&dzCtx, name, &cls.demofile);
 
 	switch (dzip_status) {
 		case DZIP_ALREADY_EXTRACTING:
@@ -574,7 +574,7 @@ static void PlayDZDemo (void)
 			StartPlayingOpenedDemo ();
 			break;
 		case DZIP_EXTRACT_FAIL:
-			// Error message printed by `Dzip_StartExtract`.
+			// Error message printed by `DZip_StartExtract`.
 			break;
 		case DZIP_EXTRACT_IN_PROGRESS:
 			Con_Printf ("\x02" "\nunpacking demo. please wait...\n\n");

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -73,6 +73,13 @@ void CL_InitDemo (void)
 	DZip_Cleanup(&dzCtx);
 }
 
+
+void CL_ShutdownDemo (void)
+{
+	DZip_Cleanup(&dzCtx);
+}
+
+
 /*
 ==============
 CL_StopPlayback

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -534,14 +534,6 @@ static void CheckDZipCompletion (void)
 
 	dz_unpacking = false;
 
-	if (!(cls.demofile = fopen(tempdem_name, "rb")))
-	{
-		Con_Printf ("ERROR: couldn't open %s\n", tempdem_name);
-		dz_playback = cls.demoplayback = false;
-		cls.demonum = -1;
-		return;
-	}
-
 	// start playback
 	StartPlayingOpenedDemo ();
 }

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -69,7 +69,7 @@ read from the demo file.
 
 void CL_InitDemo (void)
 {
-	DZip_Init(&dzCtx, "dzip_playdemo");
+	DZip_Init(&dzCtx, "playdemo");
 	DZip_Cleanup(&dzCtx);
 }
 

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -500,31 +500,24 @@ void StartPlayingOpenedDemo (void)
 // joe: playing demos from .dz files
 static void CheckDZipCompletion (void)
 {
-#ifdef _WIN32
-	DWORD	ExitCode;
+    dzip_status_t dzip_status;
 
-	if (!hDZipProcess)
-		return;
+    dzip_status = Dzip_CheckCompletion(dzCtx);
 
-	if (!GetExitCodeProcess(hDZipProcess, &ExitCode))
-	{
-		Con_Printf ("WARNING: GetExitCodeProcess failed\n");
-		hDZipProcess = NULL;
-		dz_unpacking = dz_playback = cls.demoplayback = false;
-		StopDZPlayback ();
-		return;
-	}
-
-	if (ExitCode == STILL_ACTIVE)
-		return;
-
-	hDZipProcess = NULL;
-#else
-	if (!hDZipProcess)
-		return;
-
-	hDZipProcess = false;
-#endif
+    switch (dzip_status) {
+        case DZIP_NOT_EXTRACTING:
+        case DZIP_EXTRACT_IN_PROGRESS:
+            return;
+        case DZIP_EXTRACT_FAIL:
+            dz_unpacking = dz_playback = cls.demoplayback = false;
+            StopDZPlayback ();
+            return;
+        case DZIP_EXTRACT_SUCCESS:
+            break;
+        default:
+            Sys_Error("Invalid dzip status %d", dzip_status);
+            return;
+    }
 
 	if (!dz_unpacking || !cls.demoplayback)
 	{

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -541,6 +541,7 @@ static void CheckDZipCompletion (void)
 
 static void StopDZPlayback (void)
 {
+	DZip_Cleanup(&dzCtx);
 	dz_playback = false;
 }
 

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -560,24 +560,22 @@ static void PlayDZDemo (void)
 
 	name = Cmd_Argv(1);
 
-	if (Dzip_Extracting(&dzCtx)) {
-		Con_Printf ("Cannot unpack -- DZip is still running!\n");
-		return;
-	}
-
 	dzip_status = Dzip_StartExtract(&dzCtx, name, &cls.demofile);
 
 	switch (dzip_status) {
+		case DZIP_ALREADY_EXTRACTING:
+			Con_Printf ("Cannot unpack -- DZip is still running!\n");
+			break;
 		case DZIP_NO_EXIST:
 			Con_Printf ("ERROR: couldn't open %s\n", name);
-			return;
+			break;
 		case DZIP_EXTRACT_SUCCESS:
 			Con_Printf ("Already extracted, playing demo\n");
 			StartPlayingOpenedDemo ();
-			return;
+			break;
 		case DZIP_EXTRACT_FAIL:
 			// Error message printed by `Dzip_StartExtract`.
-			return;
+			break;
 		case DZIP_EXTRACT_IN_PROGRESS:
 			Con_Printf ("\x02" "\nunpacking demo. please wait...\n\n");
 			key_dest = key_game;
@@ -589,7 +587,7 @@ static void PlayDZDemo (void)
 			cls.demoplayback = true;
 			cls.demofile = NULL;
 			cls.state = ca_connected;
-			return;
+			break;
 	}
 }
 

--- a/trunk/cl_dzip.c
+++ b/trunk/cl_dzip.c
@@ -43,7 +43,7 @@ DZip_Init (dzip_context_t *ctx, const char *prefix)
 	memset(ctx, 0, sizeof(*ctx));
 
     Q_snprintfz (ctx->extract_dir, sizeof(ctx->extract_dir),
-				 "%s/%s", com_basedir, prefix);
+				 "%s/%s/", com_basedir, prefix);
 
 #ifdef _WIN32
     ctx->proc = NULL;

--- a/trunk/cl_dzip.c
+++ b/trunk/cl_dzip.c
@@ -48,16 +48,16 @@ DZip_Init (dzip_context_t *ctx, const char *prefix)
 {
 	memset(ctx, 0, sizeof(*ctx));
 
-    Q_snprintfz (ctx->extract_dir, sizeof(ctx->extract_dir),
+	Q_snprintfz (ctx->extract_dir, sizeof(ctx->extract_dir),
 				 "%s/%s/%s/", com_basedir, DZIP_EXTRACT_DIR, prefix);
 
 #ifdef _WIN32
-    ctx->proc = NULL;
+	ctx->proc = NULL;
 #else
-    ctx->proc = false;
+	ctx->proc = false;
 #endif
 
-    ctx->dem_path[0] = '\0';
+	ctx->dem_path[0] = '\0';
 	ctx->demo_file_p = NULL;
 	ctx->initialized = true;
 }

--- a/trunk/cl_dzip.c
+++ b/trunk/cl_dzip.c
@@ -91,12 +91,13 @@ DZip_Extracting (dzip_context_t *ctx)
 dzip_status_t
 DZip_StartExtract (dzip_context_t *ctx, const char *name, FILE **demo_file_p)
 {
-	char	dem_basedir[MAX_OSPATH];
-	char	*p, dz_name[MAX_OSPATH];
-	char	tempdir[MAX_OSPATH];
+	char	dem_basedir[1024];
+	char	*p, dz_name[1024];
+	char	tempdir[1024];
 	FILE    *demo_file;
 #ifdef _WIN32
-	char	cmdline[512];
+	char	cmdline[1024];
+	char	abs_dz_name[1024];
 	STARTUPINFO si;
 	PROCESS_INFORMATION pi;
 #else
@@ -156,7 +157,13 @@ DZip_StartExtract (dzip_context_t *ctx, const char *name, FILE **demo_file_p)
 	si.wShowWindow = SW_HIDE;
 	si.dwFlags = STARTF_USESHOWWINDOW;
 
-	Q_snprintfz (cmdline, sizeof(cmdline), "%s/dzip.exe -x -f \"%s\"", com_basedir, name);
+	if (GetFullPathName(dz_name, sizeof(abs_dz_name), abs_dz_name, NULL) == 0)
+	{
+		Con_Printf("GetFullPathName failed on %s\n", dz_name);
+		return DZIP_EXTRACT_FAIL;
+	}
+
+	Q_snprintfz(cmdline, sizeof(cmdline), "%s/dzip.exe -x -f \"%s\"", com_basedir, abs_dz_name);
 	if (!CreateProcess(NULL, cmdline, NULL, NULL, FALSE, 0, NULL, ctx->extract_dir, &si, &pi))
 	{
 		Con_Printf ("Couldn't execute %s/dzip.exe\n", com_basedir);

--- a/trunk/cl_dzip.c
+++ b/trunk/cl_dzip.c
@@ -57,6 +57,17 @@ DZip_Init (dzip_context_t *ctx, const char *prefix)
 
     ctx->dem_path[0] = '\0';
 	ctx->demo_file_p = NULL;
+	ctx->initialized = true;
+}
+
+
+static void
+DZip_CheckInitialized (dzip_context_t *ctx)
+{
+	if (!ctx->initialized)
+	{
+		Sys_Error("Attempt to use uninitialized dzip context");
+	}
 }
 
 
@@ -110,6 +121,8 @@ DZip_StartExtract (dzip_context_t *ctx, const char *name, FILE **demo_file_p)
 	pid_t	pid;
 	int		wstatus;
 #endif
+
+	DZip_CheckInitialized (ctx);
 
 	if (DZip_Extracting(ctx)) {
 		return DZIP_ALREADY_EXTRACTING;
@@ -240,6 +253,8 @@ static dzip_status_t
 DZip_CheckOrWaitCompletion (dzip_context_t *ctx, qboolean wait)
 {
 	FILE *demo_file;
+
+	DZip_CheckInitialized (ctx);
 
 	if (!DZip_Extracting(ctx)) {
 		return DZIP_NOT_EXTRACTING;
@@ -442,6 +457,7 @@ DZip_Cleanup_Callback(const char *fpath, const struct stat *sb, int typeflag,
 void
 DZip_Cleanup(dzip_context_t *ctx)
 {
+	DZip_CheckInitialized (ctx);
 #ifdef _WIN32
 	DZip_RecursiveDirectoryCleanup(ctx, ctx->extract_dir);
 #else

--- a/trunk/cl_dzip.c
+++ b/trunk/cl_dzip.c
@@ -1,0 +1,77 @@
+typedef enum {
+    DZIP_NOT_EXTRACTING,
+    DZIP_EXTRACT_IN_PROGRESS,
+    DZIP_EXTRACT_FAIL,
+    DZIP_EXTRACT_SUCCESS,
+} dzip_status_t;
+
+
+typedef struct {
+    const char prefix[MAX_OSPATH];
+
+#ifdef _WIN32
+    static HANDLE proc = NULL;
+#else
+#include <errno.h>
+#include <sys/wait.h>
+#include <unistd.h>
+    static qboolean proc = false;
+#endif
+} dzip_context_t;
+
+
+void
+DZip_Init (dzip_context_t *ctx, char *prefix)
+{
+    Q_strncpyz (ctx->prefix, prefix, sizeof(ctx->prefix));
+
+#ifdef _WIN32
+    ctx->proc = NULL;
+#else
+    ctx->proc = false;
+#endif
+}
+
+
+static bool
+DZip_Extracting (dzip_context_t *ctx)
+{
+#ifdef _WIN32
+    return ctx->proc != NULL;
+#else
+    return ctx->proc;
+#endif
+}
+
+
+dzip_status_t
+DZip_CheckCompletion (dzip_context_t *ctx)
+{
+    if (!DZip_Extracting(ctx)) {
+        return DZIP_NOT_EXTRACTING;
+    }
+
+#ifdef _WIN32
+	DWORD	ExitCode;
+
+	if (!GetExitCodeProcess(hDZipProcess, &ExitCode))
+	{
+		Con_Printf ("WARNING: GetExitCodeProcess failed\n");
+		ctx->proc = NULL;
+
+        // Move into caller
+		//dz_unpacking = dz_playback = cls.demoplayback = false;
+		//StopDZPlayback ();
+		return DZIP_EXTRACT_FAIL;
+	}
+
+	if (ExitCode == STILL_ACTIVE)
+		return DZIP_EXTRACT_IN_PROGRESS;
+
+	ctx->proc = NULL;
+#else
+	ctx->proc = false;
+#endif
+
+    return DZIP_EXTRACT_SUCCESS;
+}

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -1385,6 +1385,7 @@ void CL_Init (void)
 	CL_InitModelnames ();
 	CL_InitTEnts ();
 	Ghost_Init ();
+    CL_InitDemo ();
 
 // register our commands
 	Cvar_Register (&cl_name);
@@ -1436,4 +1437,6 @@ void CL_Init (void)
 	Cmd_AddCommand ("playdemo", CL_PlayDemo_f);
 	Cmd_AddCommand ("timedemo", CL_TimeDemo_f);
 	Cmd_AddCommand("keepdemo", CL_KeepDemo_f);
+
+
 }

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -1440,3 +1440,15 @@ void CL_Init (void)
 
 
 }
+
+
+/*
+=================
+CL_Shutdown
+=================
+*/
+void CL_Shutdown (void)
+{
+    Ghost_Shutdown();
+    CL_ShutdownDemo();
+}

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -1385,7 +1385,7 @@ void CL_Init (void)
 	CL_InitModelnames ();
 	CL_InitTEnts ();
 	Ghost_Init ();
-    CL_InitDemo ();
+	CL_InitDemo ();
 
 // register our commands
 	Cvar_Register (&cl_name);

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -409,23 +409,22 @@ typedef enum {
 } dzip_status_t;
 typedef struct {
     // Directory into which dzip files will be extracted.
-    const char extract_dir[MAX_OSPATH];
+    char extract_dir[MAX_OSPATH];
 
     // Full path of the extracted demo file.
-    const char dem_path[MAX_OSPATH];
+    char dem_path[MAX_OSPATH];
 
 	// When opened, file pointer will be put here.
 	FILE **demo_file_p;
 
 #ifdef _WIN32
-    static HANDLE proc = NULL;
+    HANDLE proc;
 #else
-    static qboolean proc = false;
+    qboolean proc;
 #endif
 } dzip_context_t;
 void DZip_Init (dzip_context_t *ctx, const char *prefix);
 dzip_status_t DZip_StartExtract (dzip_context_t *ctx, const char *name, FILE **demo_file_p);
-bool DZip_Extracting (dzip_context_t *ctx);
 dzip_status_t DZip_CheckCompletion (dzip_context_t *ctx);
 void DZip_Cleanup(dzip_context_t *ctx);
 

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -396,6 +396,40 @@ void CL_UpdateTEnts (void);
 entity_t *CL_NewTempEntity (void);
 qboolean TraceLineN (vec3_t start, vec3_t end, vec3_t impact, vec3_t normal);
 
+
+// cl_dzip.c
+typedef enum {
+    DZIP_INVALID,
+    DZIP_NOT_EXTRACTING,
+    DZIP_NO_EXIST,
+    DZIP_ALREADY_EXTRACTING,
+    DZIP_EXTRACT_IN_PROGRESS,
+    DZIP_EXTRACT_FAIL,
+    DZIP_EXTRACT_SUCCESS,
+} dzip_status_t;
+typedef struct {
+    // Directory into which dzip files will be extracted.
+    const char extract_dir[MAX_OSPATH];
+
+    // Full path of the extracted demo file.
+    const char dem_path[MAX_OSPATH];
+
+	// When opened, file pointer will be put here.
+	FILE **demo_file_p;
+
+#ifdef _WIN32
+    static HANDLE proc = NULL;
+#else
+    static qboolean proc = false;
+#endif
+} dzip_context_t;
+void DZip_Init (dzip_context_t *ctx, const char *prefix);
+dzip_status_t DZip_StartExtract (dzip_context_t *ctx, const char *name, FILE **demo_file_p);
+bool DZip_Extracting (dzip_context_t *ctx);
+dzip_status_t DZip_CheckCompletion (dzip_context_t *ctx);
+void DZip_Cleanup(dzip_context_t *ctx);
+
+
 #ifdef GLQUAKE
 dlighttype_t SetDlightColor (float f, dlighttype_t def, qboolean random);
 #endif

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -426,6 +426,7 @@ typedef struct {
 void DZip_Init (dzip_context_t *ctx, const char *prefix);
 dzip_status_t DZip_StartExtract (dzip_context_t *ctx, const char *name, FILE **demo_file_p);
 dzip_status_t DZip_CheckCompletion (dzip_context_t *ctx);
+dzip_status_t DZip_Open(dzip_context_t *ctx, const char *name, FILE **demo_file_p);
 void DZip_Cleanup(dzip_context_t *ctx);
 
 

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -308,6 +308,7 @@ dlight_t *CL_AllocDlight (int key);
 void CL_DecayLights (void);
 
 void CL_Init (void);
+void CL_Shutdown (void);
 
 void CL_EstablishConnection (char *host);
 void CL_Signon1 (void);
@@ -370,6 +371,7 @@ float CL_KeyState (kbutton_t *key);
 
 // cl_demo.c
 void CL_InitDemo(void);
+void CL_ShutdownDemo (void);
 void CL_StopPlayback (void);
 int CL_GetMessage (void);
 void CL_Stop_f (void);

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -406,30 +406,30 @@ qboolean TraceLineN (vec3_t start, vec3_t end, vec3_t impact, vec3_t normal);
 
 // cl_dzip.c
 typedef enum {
-    DZIP_INVALID,
-    DZIP_NOT_EXTRACTING,
-    DZIP_NO_EXIST,
-    DZIP_ALREADY_EXTRACTING,
-    DZIP_EXTRACT_IN_PROGRESS,
-    DZIP_EXTRACT_FAIL,
-    DZIP_EXTRACT_SUCCESS,
+	DZIP_INVALID,
+	DZIP_NOT_EXTRACTING,
+	DZIP_NO_EXIST,
+	DZIP_ALREADY_EXTRACTING,
+	DZIP_EXTRACT_IN_PROGRESS,
+	DZIP_EXTRACT_FAIL,
+	DZIP_EXTRACT_SUCCESS,
 } dzip_status_t;
 typedef struct {
-    qboolean initialized;
+	qboolean initialized;
 
-    // Directory into which dzip files will be extracted.
-    char extract_dir[MAX_OSPATH];
+	// Directory into which dzip files will be extracted.
+	char extract_dir[MAX_OSPATH];
 
-    // Full path of the extracted demo file.
-    char dem_path[MAX_OSPATH];
+	// Full path of the extracted demo file.
+	char dem_path[MAX_OSPATH];
 
 	// When opened, file pointer will be put here.
 	FILE **demo_file_p;
 
 #ifdef _WIN32
-    HANDLE proc;
+	HANDLE proc;
 #else
-    qboolean proc;
+	qboolean proc;
 #endif
 } dzip_context_t;
 void DZip_Init (dzip_context_t *ctx, const char *prefix);

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -19,6 +19,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // client.h
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 typedef struct
 {
 	vec3_t	viewangles;
@@ -365,6 +369,7 @@ void CL_BaseMove (usercmd_t *cmd);
 float CL_KeyState (kbutton_t *key);
 
 // cl_demo.c
+void CL_InitDemo(void);
 void CL_StopPlayback (void);
 int CL_GetMessage (void);
 void CL_Stop_f (void);

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -415,6 +415,8 @@ typedef enum {
     DZIP_EXTRACT_SUCCESS,
 } dzip_status_t;
 typedef struct {
+    qboolean initialized;
+
     // Directory into which dzip files will be extracted.
     char extract_dir[MAX_OSPATH];
 

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -497,7 +497,7 @@ static void Ghost_ShiftResetCommand_f (void)
 
 void Ghost_Init (void)
 {
-    DZip_Init (&ghost_dz_ctx, "dzip_ghost");
+    DZip_Init (&ghost_dz_ctx, "ghost");
     DZip_Cleanup(&ghost_dz_ctx);
     Cmd_AddCommand ("ghost", Ghost_Command_f);
     Cmd_AddCommand ("ghost_remove", Ghost_RemoveCommand_f);

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -496,6 +496,7 @@ static void Ghost_ShiftResetCommand_f (void)
 
 void Ghost_Init (void)
 {
+    DZip_Init (&ghost_dz_ctx, "dzip_ghost");
     Cmd_AddCommand ("ghost", Ghost_Command_f);
     Cmd_AddCommand ("ghost_remove", Ghost_RemoveCommand_f);
     Cmd_AddCommand ("ghost_shift", Ghost_ShiftCommand_f);

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -156,7 +156,6 @@ void Ghost_Load (const char *map_name)
     ghost_finish_time = -1.0f;
 
     if (ghost_demo_path[0] == '\0') {
-        DZip_Cleanup(&ghost_dz_ctx);
         return;
     }
 
@@ -409,8 +408,8 @@ static void Ghost_Command_f (void)
         return;
     }
 
+    DZip_Cleanup(&ghost_dz_ctx);
     Q_strlcpy(demo_path, Cmd_Argv(1), sizeof(demo_path));
-
     demo_file = Ghost_OpenDemoOrDzip(demo_path);
     if (demo_file) {
         fclose(demo_file);
@@ -437,6 +436,7 @@ static void Ghost_RemoveCommand_f (void)
     } else {
         Con_Printf("ghost %s will be removed on next map load\n", ghost_demo_path);
         ghost_demo_path[0] = '\0';
+        DZip_Cleanup(&ghost_dz_ctx);
     }
 }
 
@@ -509,3 +509,8 @@ void Ghost_Init (void)
     Cvar_Register (&ghost_alpha);
 }
 
+
+void Ghost_Shutdown (void)
+{
+    DZip_Cleanup(&ghost_dz_ctx);
+}

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -156,6 +156,7 @@ void Ghost_Load (const char *map_name)
     ghost_finish_time = -1.0f;
 
     if (ghost_demo_path[0] == '\0') {
+        DZip_Cleanup(&ghost_dz_ctx);
         return;
     }
 
@@ -497,6 +498,7 @@ static void Ghost_ShiftResetCommand_f (void)
 void Ghost_Init (void)
 {
     DZip_Init (&ghost_dz_ctx, "dzip_ghost");
+    DZip_Cleanup(&ghost_dz_ctx);
     Cmd_AddCommand ("ghost", Ghost_Command_f);
     Cmd_AddCommand ("ghost_remove", Ghost_RemoveCommand_f);
     Cmd_AddCommand ("ghost_shift", Ghost_ShiftCommand_f);

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -107,11 +107,12 @@ static FILE *
 Ghost_OpenDemoOrDzip (const char *demo_path)
 {
     FILE *demo_file = NULL;
+    dzip_status_t dzip_status;
 
     if (strlen(demo_path) > 3
         && !Q_strcasecmp(demo_path + strlen(demo_path) - 3, ".dz"))
     {
-        dzip_status = DZip_Open(&ghost_dz_ctx, name, &demo_file);
+        dzip_status = DZip_Open(&ghost_dz_ctx, demo_path, &demo_file);
         switch (dzip_status) {
             case DZIP_ALREADY_EXTRACTING:
                 Sys_Error("Already extracting despite sync only usage");
@@ -391,7 +392,6 @@ static void Ghost_Command_f (void)
 {
     FILE *demo_file;
     char demo_path[MAX_OSPATH];
-    dzip_status_t dzip_status;
 
     if (cmd_source != src_command) {
         return;

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -107,6 +107,7 @@ void Ghost_Load (const char *map_name)
 {
     int i;
     ghost_info_t ghost_info;
+    FILE *demo_file;
 
     memset(&ghost_info, 0, sizeof(ghost_info));
     ghost_records = NULL;
@@ -118,7 +119,13 @@ void Ghost_Load (const char *map_name)
         return;
     }
 
-    if (!Ghost_ReadDemo(ghost_demo_path, &ghost_info, map_name)) {
+    COM_FOpenFile (ghost_demo_path, &demo_file);
+    if (!demo_file)
+    {
+        Con_Printf ("ERROR: couldn't open %s\n", ghost_demo_path);
+        return;
+    }
+    if (!Ghost_ReadDemo(demo_file, &ghost_info, map_name)) {
         return;
     }
     ghost_records = ghost_info.records;

--- a/trunk/ghost/ghost.h
+++ b/trunk/ghost/ghost.h
@@ -27,6 +27,7 @@ void Ghost_Draw (void);
 void Ghost_DrawGhostTime (void);
 void Ghost_Init (void);
 void Ghost_Finish (void);
+void Ghost_Shutdown (void);
 
 
 #endif /* __CL_GHOST_H */

--- a/trunk/ghost/ghost_private.h
+++ b/trunk/ghost/ghost_private.h
@@ -45,7 +45,7 @@ typedef struct {
 } ghost_info_t;
 
 
-qboolean Ghost_ReadDemo(const char *demo_path, ghost_info_t *ghost_info,
-                        const char *expected_map_name);
+qboolean Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info,
+                         const char *expected_map_name);
 
 #endif /* __GHOST_PRIVATE */

--- a/trunk/ghost/ghostparse.c
+++ b/trunk/ghost/ghostparse.c
@@ -287,7 +287,7 @@ Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info,
         .finish_time = -1,
     };
 
-	pctx.demo_file = demo_file;
+    pctx.demo_file = demo_file;
 
     if (ok) {
         dprc = DP_ReadDemo(&callbacks, &pctx);

--- a/trunk/ghost/ghostparse.c
+++ b/trunk/ghost/ghostparse.c
@@ -260,7 +260,7 @@ Ghost_UpdateName_cb (int client_num, const char *name, void *ctx)
 
 
 qboolean
-Ghost_ReadDemo (const char *demo_path, ghost_info_t *ghost_info,
+Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info,
                 const char *expected_map_name)
 {
     qboolean ok = true;
@@ -287,12 +287,7 @@ Ghost_ReadDemo (const char *demo_path, ghost_info_t *ghost_info,
         .finish_time = -1,
     };
 
-    COM_FOpenFile ((char *)demo_path, &pctx.demo_file);
-    if (!pctx.demo_file)
-    {
-        Con_Printf ("ERROR: couldn't open %s\n", demo_path);
-        ok = false;
-    }
+	pctx.demo_file = demo_file;
 
     if (ok) {
         dprc = DP_ReadDemo(&callbacks, &pctx);
@@ -300,7 +295,7 @@ Ghost_ReadDemo (const char *demo_path, ghost_info_t *ghost_info,
             // Errors from callbacks print their own error messages.
             ok = pctx.finish_time > 0;
         } else if (dprc != DP_ERR_SUCCESS) {
-            Con_Printf("Error parsing demo %s: %u\n", demo_path, dprc);
+            Con_Printf("Error parsing demo: %u\n", dprc);
             ok = false;
         }
     }

--- a/trunk/host.c
+++ b/trunk/host.c
@@ -1139,5 +1139,8 @@ void Host_Shutdown (void)
 		LOC_Shutdown();
 
 	if (cls.state != ca_dedicated)
+	{
 		VID_Shutdown ();
+		CL_Shutdown ();
+	}
 }


### PR DESCRIPTION
This PR adds support for loading ghosts from dzip files.  Like with `playdemo foo.dz` it extracts the dzip file before opening the extracted `.dem` file.  To achieve this I've moved all of the dzip logic into cl_dzip.c, and modified the `playdemo` and `ghost` logic to call into this module.  I've documented the interface for cl_dzip.c --- hopefully it is clear how it works.

In order to avoid issues of `playdemo` and `ghost` deleting each others extracted files, I've changed the logic from extracting into the same directory as the `.dz` file, to extracting into `<game dir>/extracted_dzips/{ghost,playdemo}/`, this way the extracted files are kept separate.   The `extracted_dzips/ghost` directory is cleaned up (recursively deleted) on startup, on ghost add, ghost remove, and on shutdown.  Similarly, the `extracted_dzips/playdemo` directory is cleaned up on startup, demo end, and on shutdown.

I've been slightly paranoid with the code around the recursive delete for obvious reasons.  It would be good to get some extra eyeballs in this area, as well as areas around path handling and potential command line injection issues, etc.