### PR TITLE
Fix demo rewind for changing intermission state

### DIFF
--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -886,3 +886,33 @@ void CL_KeepDemo_f(void)
 	else
 		Con_Printf("Renamed demo to %s\n", newname);
 }
+
+
+#define DEMO_INTERMISSION_BUFFER_SIZE 8
+struct {
+	int index;
+	int data[DEMO_INTERMISSION_BUFFER_SIZE];
+} static dem_intermission_buf = {0};
+
+static int DemoIntermissionStatePop (void) {
+	dem_intermission_buf.index -= 1;
+	if (dem_intermission_buf.index < 0)
+		dem_intermission_buf.index = DEMO_INTERMISSION_BUFFER_SIZE - 1;
+	return dem_intermission_buf.data[dem_intermission_buf.index];
+}
+
+static void DemoIntermissionStatePush (int value) {
+	dem_intermission_buf.data[dem_intermission_buf.index] = value;
+	dem_intermission_buf.index += 1;
+	if (dem_intermission_buf.index >= DEMO_INTERMISSION_BUFFER_SIZE)
+		dem_intermission_buf.index = 0;
+}
+
+int CL_DemoIntermissionState (int old_state, int new_state)
+{
+	if (cl_demorewind.value)
+		return DemoIntermissionStatePop();
+
+	DemoIntermissionStatePush(old_state);
+	return new_state;
+}

--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -1477,7 +1477,10 @@ void CL_ParseServerMessage (void)
 			break;
 
 		case svc_intermission:
-			cl.intermission = 1;
+			if (cls.demoplayback)
+				cl.intermission = CL_DemoIntermissionState(cl.intermission, 1);
+			else
+				cl.intermission = 1;
 			cl.completed_time = cl.mtime[0];	//joe: intermission bugfix
 			vid.recalc_refdef = true;	// go to full screen
 			PrintFinishTime();
@@ -1489,7 +1492,10 @@ void CL_ParseServerMessage (void)
 				cl.completed_time = cl.mtime[0];	//joe: intermission bugfix
 				PrintFinishTime();
 			}
-			cl.intermission = 2;
+			if (cls.demoplayback)
+				cl.intermission = CL_DemoIntermissionState(cl.intermission, 2);
+			else
+				cl.intermission = 2;
 			vid.recalc_refdef = true;	// go to full screen
 			SCR_CenterPrint (MSG_ReadString());
 			break;
@@ -1500,7 +1506,10 @@ void CL_ParseServerMessage (void)
 				cl.completed_time = cl.mtime[0];	//joe: intermission bugfix
 				PrintFinishTime();
 			}
-			cl.intermission = 3;
+			if (cls.demoplayback)
+				cl.intermission = CL_DemoIntermissionState(cl.intermission, 3);
+			else
+				cl.intermission = 3;
 			vid.recalc_refdef = true;	// go to full screen
 			SCR_CenterPrint (MSG_ReadString());
 			break;

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -372,6 +372,7 @@ void CL_Record_f (void);
 void CL_PlayDemo_f (void);
 void CL_TimeDemo_f(void);
 void CL_KeepDemo_f (void);
+int CL_DemoIntermissionState (int old_state, int new_state);
 
 // cl_parse.c
 void CL_ParseServerMessage (void);


### PR DESCRIPTION
Use a ring buffer to keep track of the last intermission states and use that to always restore the correct intermission state during demo rewinding. Storing 8 states should be more than enough.

More elaborate version of #66 