### PR TITLE
demo menu: handle few files case

### DIFF
--- a/trunk/menu.c
+++ b/trunk/menu.c
@@ -6350,7 +6350,7 @@ void M_Demos_Key (int k)
 				worx = true;
 				S_LocalSound ("misc/menu1.wav");
 				list_base = i - 10;
-				if (list_base < 0)
+				if (list_base < 0 || num_files < MAXLINES)
 				{
 					list_base = 0;
 					list_cursor = i;


### PR DESCRIPTION
This occurs when viewing a file list with more than 10, but fewer than MAXLINES files, and typing letters to skip to a file after the 10th position. For example, typing "TE" on this view:

![image](https://user-images.githubusercontent.com/1709642/196059179-140eb994-a7c5-4d39-89ae-ea0f9d869c85.png)

WIthout the fix, this case ends up falling into the `list_base > (num_files - MAXLINES)` branch and `list_base` gets set to a negative number, and so `d` gets assigned to an invalid address in `M_List_Draw`.

The fix is to drop into the first case when there are not enough files to fill the view. 

