### PR TITLE
Ghost marathon tracking improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ the direction he's looking at.
 
 ### `sv_marathontrack`
 
-When set to 1 (the default) the server informs the client about whether the map
+When set to 1 (default 0) the server informs the client about whether the map
 being played is the first in a marathon or a subsequent map.  This is necessary
 for ghost marathon splits to work when playing back a demo.  When a demo
 recorded with this option is played on an older JoeQuake or another source port

--- a/README.md
+++ b/README.md
@@ -625,6 +625,15 @@ Switches on alternative noclip movement where the player always moves towards
 the direction he's looking at.
 1 by default.
 
+### `sv_marathontrack`
+
+When set to 1 (the default) the server informs the client about whether the map
+being played is the first in a marathon or a subsequent map.  This is necessary
+for ghost marathon splits to work when playing back a demo.  When a demo
+recorded with this option is played on an older JoeQuake or another source port
+then a message `Unknown command "marathon"` will be seen on all but the first
+level.  To disable this feature set `sv_marathontrack` to 0.
+
 ## New commands
 
 ### `cmdlist`
@@ -879,6 +888,11 @@ The ghost feature shows the player from a demo file while you are playing the
 game or watching another demo file.  This is useful for speedruns to know where
 you are relative to a reference demo, and to indicate where you could be faster.
 
+#### Setting a ghost from the demo menu
+
+From the demo menu, press ctrl-enter to set a demo file as a ghost, and
+ctrl-shift-enter to remove the ghost.
+
 #### Commands
 
 - `ghost <demo-file>`:  Add ghost from the given demo file.  The ghost will be
@@ -899,6 +913,15 @@ you are relative to a reference demo, and to indicate where you could be faster.
 - `ghost_range <distance>`:  Hide the ghost when it is within this distance.
 - `ghost_alpha <float>`: Change how transparent the ghost is.  `0` is fully
   transparent, `1` is fully opaque.
+
+#### Marathon split times
+
+When a ghost is loaded at the end of each level a split time is printed to the
+console.  If a marathon demo is loaded as the ghost, and the player is also
+running a marathon, then split times for each level are shown.  Playing a
+marathon demo while a marathon ghost is loaded will also show split times,
+however the demo being played must have been recorded with `sv_marathontrack`
+set to 1.  See the documentation for `sv_marathontrack` for more details.
 
 ## NOTE for linux GLX users
 

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -242,13 +242,9 @@ void CL_Marathon_f (void)
 	if (Cmd_Argc() == 2)
 	{
 		arg = Cmd_Argv(1);
-		if (strcmp(arg, "start") == 0)
+		if (strcmp(arg, "continue") == 0)
 		{
-			cl.marathon_state = ms_start;
-			Ghost_MarathonStart();
-		} else if (strcmp(arg, "continue") == 0)
-		{
-			cl.marathon_state = ms_continue;
+			cls.marathon_state = ms_continue;
 		} else
 		{
 			Con_Printf("invalid marathon argument %s\n", arg);
@@ -1328,6 +1324,14 @@ Read all incoming data from the server
 void CL_ReadFromServer (void)
 {
 	int	ret;
+
+	if (cls.marathon_state == ms_serverinfo)
+	{
+		// No marathon command received after svc_serverinfo, so assume
+		// marathon start.
+		cls.marathon_state = ms_start;
+		Ghost_MarathonStart();
+	}
 
 	cl.oldtime = cl.ctime;
 	cl.time += host_frametime;

--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -611,9 +611,7 @@ void CL_ParseServerInfo (void)
 
 	noclip_anglehack = false;	// noclip is turned off at start
 
-	// Default marathon state.  On supported servers, it will be overridden by a
-	// stuffed `marathon [start|continue]` command.
-	cl.marathon_state = ms_unknown;
+	cls.marathon_state = ms_serverinfo;
 }
 
 /*

--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -611,7 +611,11 @@ void CL_ParseServerInfo (void)
 
 	noclip_anglehack = false;	// noclip is turned off at start
 
-	cls.marathon_state = ms_serverinfo;
+	if (cls.marathon_state == ms_continue_force) {
+		cls.marathon_state = ms_continue;
+	} else {
+		cls.marathon_state = ms_serverinfo;
+	}
 }
 
 /*

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -124,10 +124,11 @@ typedef enum
 
 typedef enum
 {
-	ms_unknown,		// initial state
-	ms_serverinfo,	// server info recieved, still reading message
-	ms_start,		// server info recieved with no `marathon continue` cmd
-	ms_continue,	// server info received with `marathon continue` cmd
+	ms_unknown,			// initial state
+	ms_serverinfo,		// server info recieved, still reading message
+	ms_continue_force, 	// set `ms_continue` next time serverinfo received
+	ms_start,			// server info recieved with no `marathon continue` cmd
+	ms_continue,		// server info received with `marathon continue` cmd
 } client_marathon_state_t;
 
 

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -124,9 +124,10 @@ typedef enum
 
 typedef enum
 {
-	ms_unknown,		// server has not indicated
-	ms_start,		// first map in a marathon
-	ms_continue,	// non-first map in marathon
+	ms_unknown,		// initial state
+	ms_serverinfo,	// server info recieved, still reading message
+	ms_start,		// server info recieved with no `marathon continue` cmd
+	ms_continue,	// server info received with `marathon continue` cmd
 } client_marathon_state_t;
 
 
@@ -163,6 +164,8 @@ typedef struct
 	qboolean	capturedemo;
 	double		marathon_time;		// joe: adds cl.completed_time at level changes
 	int			marathon_level;
+
+	client_marathon_state_t marathon_state;
 } client_static_t;
 
 extern	client_static_t	cls;
@@ -255,8 +258,6 @@ typedef struct
 
 	unsigned	protocol; //johnfitz
 	unsigned	protocolflags;
-
-	client_marathon_state_t marathon_state;
 } client_state_t;
 
 extern	client_state_t	cl;

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -397,8 +397,14 @@ void Ghost_Finish (void)
     ghost_marathon_level_t *gml;
     ghost_marathon_info_t *gmi = &ghost_marathon_info;
 
+    if (cls.marathon_state != ms_start
+            && cls.marathon_state != ms_continue) {
+        Con_Printf("ERROR: Invalid marathon state mid-game %d\n", cls.marathon_state);
+        gmi->valid = false;
+    }
+
     if (ghost_finish_time > 0) {
-        if (cl.marathon_state == ms_unknown) {
+        if (cls.marathon_state == ms_unknown) {
             if (gmi->valid) {
                 Con_Printf("Server not marathon aware, marathon stopped\n");
             }
@@ -446,9 +452,9 @@ void Ghost_Finish (void)
 
 void Ghost_MarathonStart (void)
 {
-    if (cl.marathon_state != ms_start) {
+    if (cls.marathon_state != ms_start) {
         Sys_Error("Invalid marathon_state %d for Ghost_MarathonStart",
-                cl.marathon_state);
+                  cls.marathon_state);
     }
 
     ghost_marathon_info.valid = true;

--- a/trunk/sv_main.c
+++ b/trunk/sv_main.c
@@ -341,6 +341,10 @@ void SV_SendServerinfo (client_t *client)
 			// compared when playing back a demo.
 			MSG_WriteChar (&client->message, svc_stufftext);
 			MSG_WriteString (&client->message, "marathon continue\n");
+		} else if (cls.state != ca_dedicated) {
+			// Don't send a message, but make sure `ms_continue` state is set
+			// for the connected client.
+			cls.marathon_state = ms_continue_force;
 		}
 	}
 

--- a/trunk/sv_main.c
+++ b/trunk/sv_main.c
@@ -31,7 +31,7 @@ server_static_t	svs;
 char		localmodels[MAX_MODELS][LOCALMODELS_STRING_SIZE];	// inline model names for precache
 
 int			sv_protocol = PROTOCOL_NETQUAKE;
-static cvar_t		sv_marathontrack = {"sv_marathontrack", "1", CVAR_ARCHIVE};
+static cvar_t		sv_marathontrack = {"sv_marathontrack", "0", CVAR_ARCHIVE};
 
 extern qboolean	pr_alpha_supported; //johnfitz 
 

--- a/trunk/sv_main.c
+++ b/trunk/sv_main.c
@@ -31,6 +31,7 @@ server_static_t	svs;
 char		localmodels[MAX_MODELS][LOCALMODELS_STRING_SIZE];	// inline model names for precache
 
 int			sv_protocol = PROTOCOL_NETQUAKE;
+static cvar_t		sv_marathontrack = {"sv_marathontrack", "1", CVAR_ARCHIVE};
 
 extern qboolean	pr_alpha_supported; //johnfitz 
 
@@ -60,6 +61,7 @@ void SV_Init (void)
 	Cvar_Register (&sv_aim);
 	Cvar_Register (&sv_nostep);
 	Cvar_Register (&sv_altnoclip); //johnfitz
+	Cvar_Register (&sv_marathontrack);
 
 	for (i=0 ; i<MAX_MODELS ; i++)
 		sprintf (localmodels[i], "*%i", i);
@@ -334,8 +336,12 @@ void SV_SendServerinfo (client_t *client)
 
 	// Tell client about if this level is a continuation of a marathon.
 	if (sv.changelevel_issued) {
-		MSG_WriteChar (&client->message, svc_stufftext);
-		MSG_WriteString (&client->message, "marathon continue\n");
+		if (sv_marathontrack.value) {
+			// Send a message over the net, so that ghost split times can be
+			// compared when playing back a demo.
+			MSG_WriteChar (&client->message, svc_stufftext);
+			MSG_WriteString (&client->message, "marathon continue\n");
+		}
 	}
 
 	client->sendsignon = true;

--- a/trunk/sv_main.c
+++ b/trunk/sv_main.c
@@ -332,11 +332,9 @@ void SV_SendServerinfo (client_t *client)
 	MSG_WriteByte (&client->message, svc_signonnum);
 	MSG_WriteByte (&client->message, 1);
 
-	// Tell client about the marathon state.
-	MSG_WriteChar (&client->message, svc_stufftext);
-	if (!sv.changelevel_issued) {
-		MSG_WriteString (&client->message, "marathon start\n");
-	} else {
+	// Tell client about if this level is a continuation of a marathon.
+	if (sv.changelevel_issued) {
+		MSG_WriteChar (&client->message, svc_stufftext);
 		MSG_WriteString (&client->message, "marathon continue\n");
 	}
 


### PR DESCRIPTION
A few changes which limit or control when the extra marathon command is sent from server to client.  I want to keep this message configurable and low impact since it effects the demo format and shows up as noise when played back with incompatible clients.

The changes are as follows:
- Only send the `svc_stufftext marathon` command for marathon continuation levels (ie. do not send for the first level in a marathon).  If a `svc_serverinfo` is received without a `svc_stufftext marathon`, it is assumed to be the start of a marathon.
- Add a new cvar `sv_marathontrack` which when set to 0 disables sending of `svc_stufftext marathon` altogether.  This means marathon split comparisons can't be done between a ghost and a demo that were not recorded with `sv_marathontrack` set to 1...
- ...however a fallback has been added when `sv_marathontrack` is set to 0 and the client is directly connected to the server (ie. not in demo playback or connected via the network).  In this case, the server directly interacts with the client code to inform it of marathon continuation.
- Update the README to explain marathon splits and the new cvar.