### PR TITLE
Ghost: Respect model field in updates

### DIFF
--- a/trunk/ghost/demoparse.c
+++ b/trunk/ghost/demoparse.c
@@ -394,6 +394,7 @@ DP_ParseBaseline(ctx_t *ctx, qboolean static_, int version)
 {
     short entity_num;
     int frame;
+    int model;
     byte bits = 0;
     vec3_t origin, angle;
     int i;
@@ -407,9 +408,13 @@ DP_ParseBaseline(ctx_t *ctx, qboolean static_, int version)
     }
 
     if (bits & B_LARGEMODEL) {
-        CHECK_RC(DP_ParseShort(ctx, NULL));  // model
+        short model_s;
+        CHECK_RC(DP_ParseShort(ctx, &model_s));
+        model = model_s;
     } else {
-        CHECK_RC(DP_ParseByte(ctx, NULL));  // model
+        byte model_b;
+        CHECK_RC(DP_ParseByte(ctx, &model_b));
+        model = model_b;
     }
 
     if (bits & B_LARGEFRAME) {
@@ -435,7 +440,7 @@ DP_ParseBaseline(ctx_t *ctx, qboolean static_, int version)
     }
 
     if (!static_) {
-        CALL_CALLBACK(baseline, entity_num, origin, angle, frame);
+        CALL_CALLBACK(baseline, entity_num, origin, angle, frame, model);
     }
 
     return DP_ERR_SUCCESS;
@@ -478,6 +483,7 @@ DP_ParseUpdate(ctx_t *ctx, byte base_flags)
     unsigned int flags;
     int entity_num;
     int frame = -1;
+    int model = -1;
     vec3_t origin;
     vec3_t angle;
     byte origin_bits = 0;
@@ -498,7 +504,9 @@ DP_ParseUpdate(ctx_t *ctx, byte base_flags)
         entity_num = entity_num_b;
     }
     if (flags & U_MODEL) {
-        CHECK_RC(DP_ParseByte(ctx, NULL));  // model
+        byte model_b;
+        CHECK_RC(DP_ParseByte(ctx, &model_b));
+        model = model_b;
     }
     if (flags & U_FRAME) {
         byte frame_b;
@@ -555,7 +563,9 @@ DP_ParseUpdate(ctx_t *ctx, byte base_flags)
             frame |= frame_upper << 8;
         }
         if (flags & U_MODEL2) {
-            CHECK_RC(DP_ParseByte(ctx, NULL));  // model upper
+            byte model_upper;
+            CHECK_RC(DP_ParseByte(ctx, &model_upper));
+            model |= model_upper << 8;
         }
         if (flags & U_LERPFINISH) {
             CHECK_RC(DP_ParseByte(ctx, NULL));  // lerp finish
@@ -571,7 +581,7 @@ DP_ParseUpdate(ctx_t *ctx, byte base_flags)
     }
 
     CALL_CALLBACK(update, entity_num, origin, angle, origin_bits, angle_bits,
-                  frame);
+                  frame, model);
 
     return DP_ERR_SUCCESS;
 }

--- a/trunk/ghost/demoparse.h
+++ b/trunk/ghost/demoparse.h
@@ -64,10 +64,10 @@ typedef struct {
     dp_cb_response_t (*server_info_sound)(const char *level_name, void *ctx);
     dp_cb_response_t (*time)(float time, void *ctx);
     dp_cb_response_t (*baseline)(int entity_num, vec3_t origin, vec3_t angle,
-                                 int frame, void *ctx);
+                                 int frame, int model, void *ctx);
     dp_cb_response_t (*update)(int entity_num, vec3_t origin, vec3_t angle,
                                byte origin_bits, byte angle_bits, int frame,
-                               void *ctx);
+                               int model, void *ctx);
     dp_cb_response_t (*packet_end)(void *ctx);
     dp_cb_response_t (*set_view)(int entity_num, void *ctx);
     dp_cb_response_t (*intermission)(void *ctx);

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -211,8 +211,6 @@ void Ghost_Load (const char *map_name)
     ghost_entity = (entity_t *)Hunk_AllocName(sizeof(entity_t),
                                               "ghost_entity");
 
-	ghost_entity->colormap = cl_entities[cl.viewentity].colormap;
-	//ghost_entity->colormap = vid.colormap;  // TODO: Cvar for colors.
 	ghost_entity->skinnum = 0;
     ghost_entity->modelindex = -1;
     ghost_entity->translate_start_time = 0.0f;
@@ -293,13 +291,16 @@ static qboolean Ghost_Update (void)
         rec_before = &ghost_records[after_idx - 1];
 
         ghost_show = false;
-
         for (i = 0; !ghost_show && i < GHOST_MODEL_COUNT; i++) {
             if (ghost_model_indices[i] != 0
                     && rec_after->model == ghost_model_indices[i]) {
                 ghost_show = true;
                 ghost_entity->model = Mod_ForName((char *)ghost_model_paths[i],
                                                   false);
+                ghost_entity->colormap =
+                    i == GHOST_MODEL_PLAYER
+                    ? cl_entities[cl.viewentity].colormap
+                    : vid.colormap;
             }
         }
     }

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -39,6 +39,7 @@ static int          ghost_model_indices[GHOST_MODEL_COUNT];
 const char *ghost_model_paths[GHOST_MODEL_COUNT] = {
     "progs/player.mdl",
     "progs/eyes.mdl",
+    "progs/h_player.mdl",
 };
 
 #define MAX_MARATHON_LEVELS     256

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -283,7 +283,6 @@ static qboolean Ghost_Update (void)
     float frac;
     qboolean ghost_show;
     int i;
-    const char *model_path;
 
     ghost_show = (after_idx != -1);
 

--- a/trunk/ghost/ghost_private.h
+++ b/trunk/ghost/ghost_private.h
@@ -31,8 +31,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 typedef enum {
     GHOST_MODEL_PLAYER = 0,
-    GHOST_MODEL_EYES = 1,
-    GHOST_MODEL_COUNT = 2,
+    GHOST_MODEL_EYES,
+    GHOST_MODEL_HEAD,
+    GHOST_MODEL_COUNT,
 } ghost_model_t;
 
 

--- a/trunk/ghost/ghost_private.h
+++ b/trunk/ghost/ghost_private.h
@@ -29,11 +29,19 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define GHOST_MAX_CLIENTS   8
 
 
+typedef enum {
+    GHOST_MODEL_PLAYER = 0,
+    GHOST_MODEL_EYES = 1,
+    GHOST_MODEL_COUNT = 2,
+} ghost_model_t;
+
+
 typedef struct {
     float time;
     float origin[3];
     float angle[3];
     unsigned int frame;
+    unsigned int model;
 } ghostrec_t;
 
 
@@ -42,8 +50,10 @@ typedef struct {
     float finish_time;
     ghostrec_t *records;
     int num_records;
+    int model_indices[GHOST_MODEL_COUNT];
 } ghost_info_t;
 
+extern const char *ghost_model_paths[GHOST_MODEL_COUNT];
 
 qboolean Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info,
                          const char *expected_map_name);

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -1654,7 +1654,7 @@ void R_DrawAliasModel (entity_t *ent)
 			extern int player_32bit_skins[14];
 			extern qboolean player_32bit_skins_loaded;
 
-			if ((clmodel->modhint == MOD_PLAYER || ent == ghost_entity) && player_32bit_skins_loaded && gl_externaltextures_models.value)
+			if (clmodel->modhint == MOD_PLAYER && player_32bit_skins_loaded && gl_externaltextures_models.value)
 			{
 				texture = player_32bit_skins[cl.scores[i-1].colors / 16];
 			}


### PR DESCRIPTION
Currently the player model is hard-coded as the model used by the ghost.  This makes the player appear weird when they have the ring of shadows (when the model should be a pair of eyes) and when the player is gibbed (when the model should be the head model).

This PR makes the following changes:
- Parse the model field out of update and baseline messages
- Passes the result through to the ghost module
- The ghost module loads the appropriate model depending on the current frame

Fixes https://github.com/j0zzz/JoeQuake/issues/74