### PR TITLE
remove marathon command

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,15 +625,6 @@ Switches on alternative noclip movement where the player always moves towards
 the direction he's looking at.
 1 by default.
 
-### `sv_marathontrack`
-
-When set to 1 (default 0) the server informs the client about whether the map
-being played is the first in a marathon or a subsequent map.  This is necessary
-for ghost marathon splits to work when playing back a demo.  When a demo
-recorded with this option is played on an older JoeQuake or another source port
-then a message `Unknown command "marathon"` will be seen on all but the first
-level.  To disable this feature set `sv_marathontrack` to 0.
-
 ## New commands
 
 ### `cmdlist`
@@ -916,12 +907,10 @@ ctrl-shift-enter to remove the ghost.
 
 #### Marathon split times
 
-When a ghost is loaded at the end of each level a split time is printed to the
-console.  If a marathon demo is loaded as the ghost, and the player is also
-running a marathon, then split times for each level are shown.  Playing a
-marathon demo while a marathon ghost is loaded will also show split times,
-however the demo being played must have been recorded with `sv_marathontrack`
-set to 1.  See the documentation for `sv_marathontrack` for more details.
+When a ghost is loaded a split time is printed to the console at the end of each
+level.  If a marathon demo is loaded as the ghost, and the player is also
+running a marathon, then split times for each level are shown.  Marathon splits
+are not shown when playing back demos.
 
 ## NOTE for linux GLX users
 

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -227,35 +227,6 @@ void CL_Disconnect_f (void)
 		Host_ShutdownServer (false);
 }
 
-/*
-=====================
-CL_Marathon_f
-
-Command sent by the server to indicate whether the current level is the first in
-a marathon, or a subsequent level.
-=====================
-*/
-void CL_Marathon_f (void)
-{
-	const char *arg;
-
-	if (Cmd_Argc() == 2)
-	{
-		arg = Cmd_Argv(1);
-		if (strcmp(arg, "continue") == 0)
-		{
-			cls.marathon_state = ms_continue;
-		} else
-		{
-			Con_Printf("invalid marathon argument %s\n", arg);
-		}
-	}
-	else
-	{
-		Con_Printf("marathon command is for internal use\n");
-	}
-}
-
 
 /*
 =====================
@@ -1325,14 +1296,6 @@ void CL_ReadFromServer (void)
 {
 	int	ret;
 
-	if (cls.marathon_state == ms_serverinfo)
-	{
-		// No marathon command received after svc_serverinfo, so assume
-		// marathon start.
-		cls.marathon_state = ms_start;
-		Ghost_MarathonStart();
-	}
-
 	cl.oldtime = cl.ctime;
 	cl.time += host_frametime;
 	if (!cl_demorewind.value || !cls.demoplayback)
@@ -1476,7 +1439,6 @@ void CL_Init (void)
 	Cmd_AddCommand ("playdemo", CL_PlayDemo_f);
 	Cmd_AddCommand ("timedemo", CL_TimeDemo_f);
 	Cmd_AddCommand("keepdemo", CL_KeepDemo_f);
-	Cmd_AddCommand ("marathon", CL_Marathon_f);
 
 
 }

--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -610,12 +610,6 @@ void CL_ParseServerInfo (void)
 	Hunk_Check ();			// make sure nothing is hurt
 
 	noclip_anglehack = false;	// noclip is turned off at start
-
-	if (cls.marathon_state == ms_continue_force) {
-		cls.marathon_state = ms_continue;
-	} else {
-		cls.marathon_state = ms_serverinfo;
-	}
 }
 
 /*

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -122,16 +122,6 @@ typedef enum
 } cactive_t;
 
 
-typedef enum
-{
-	ms_unknown,			// initial state
-	ms_serverinfo,		// server info recieved, still reading message
-	ms_continue_force, 	// set `ms_continue` next time serverinfo received
-	ms_start,			// server info recieved with no `marathon continue` cmd
-	ms_continue,		// server info received with `marathon continue` cmd
-} client_marathon_state_t;
-
-
 // the client_static_t structure is persistant through an arbitrary number
 // of server connections
 typedef struct
@@ -165,8 +155,6 @@ typedef struct
 	qboolean	capturedemo;
 	double		marathon_time;		// joe: adds cl.completed_time at level changes
 	int			marathon_level;
-
-	client_marathon_state_t marathon_state;
 } client_static_t;
 
 extern	client_static_t	cls;

--- a/trunk/ghost/ghost.h
+++ b/trunk/ghost/ghost.h
@@ -27,7 +27,6 @@ void Ghost_Draw (void);
 void Ghost_DrawGhostTime (void);
 void Ghost_Init (void);
 void Ghost_Finish (void);
-void Ghost_MarathonStart (void);
 void Ghost_Shutdown (void);
 
 extern char         ghost_demo_path[MAX_OSPATH];

--- a/trunk/server.h
+++ b/trunk/server.h
@@ -75,8 +75,6 @@ typedef struct
 
 	unsigned	protocol; //johnfitz
 	unsigned	protocolflags;
-
-	qboolean changelevel_issued;	// whether map was loaded via changelevel trigger
 } server_t;
 
 #define	NUM_PING_TIMES		16


### PR DESCRIPTION
can no longer track ghost splits when playing a demo, but the code is significantly simplified.