### PR TITLE
revert to old behaviour for dzip playdemo

### DIFF
--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -43,8 +43,6 @@ static qboolean hDZipProcess = false;
 
 static dzip_context_t dzCtx;
 static qboolean	dz_playback = false;
-static	char	tempdem_name[256] = "";	// this file must be deleted after playback is finished
-static	char	dem_basedir[256] = "";
 qboolean	dz_unpacking = false;
 static	void CheckDZipCompletion ();
 static	void StopDZPlayback ();
@@ -69,7 +67,7 @@ read from the demo file.
 
 void CL_InitDemo (void)
 {
-	DZip_Init(&dzCtx, "playdemo");
+	DZip_Init(&dzCtx, NULL);
 	DZip_Cleanup(&dzCtx);
 }
 

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -419,11 +419,15 @@ typedef enum {
 typedef struct {
 	qboolean initialized;
 
+    // If true files will be extracted into a temporary directory.  If false,
+    // files will be extracted into the same directory as the dzip file.
+    qboolean use_temp_dir;
+
 	// Directory into which dzip files will be extracted.
-	char extract_dir[MAX_OSPATH];
+	char extract_dir[1024];
 
 	// Full path of the extracted demo file.
-	char dem_path[MAX_OSPATH];
+	char dem_path[1024];
 
 	// When opened, file pointer will be put here.
 	FILE **demo_file_p;


### PR DESCRIPTION
The old behaviour was useful when playing coop demos since it leaves the secondary demos adjacent to the dzip file after playing the primary demo, which are otherwise inaccessible.  I've also fixed a couple of bugs in this area.  I'll leave comments explaining where I've done this