### PR TITLE
Port quakespasm fix for initializing temp entities during savestate load

### DIFF
--- a/trunk/host_cmd.c
+++ b/trunk/host_cmd.c
@@ -681,7 +681,15 @@ void Host_Loadgame_f (void)
 		else
 		{	// parse an edict
 			ent = EDICT_NUM(entnum);
-			memset (&ent->v, 0, progs->entityfields * 4);
+			if (entnum < sv.num_edicts) {
+				memset (&ent->v, 0, progs->entityfields * 4);
+			}
+			else if (entnum < sv.max_edicts) {
+				memset (ent, 0, pr_edict_size);
+			}
+			else {
+				Host_Error ("Loadgame: no free edicts (max_edicts is %i)", sv.max_edicts);
+			}
 			ent->free = false;
 			ED_ParseEdict (start, ent);
 	


### PR DESCRIPTION
I was getting a semi-reliable crash on my Linux branch with this, and I think it is at least theoretically possible for bad things to happen in Windows too so best fix it on the main branch.

This is a direct port of this Quakespasm commit:
   https://github.com/sezero/quakespasm/commit/de4bea0e74075857f2b22ab657b98f827a1297df

Steps to reproduce on Linux:
1. Checkout https://github.com/matthewearl/JoeQuake-1/commit/008e6cd0aaf322ed5f45dc29628b60a9bc0c98b7 and build (this is Sphere's linux branch with Joe's master branch pulled in).
2. Install [speedrunner jam](https://www.slipseer.com/index.php?resources/speedrunner-map-jam.241/)
3. Unzip [bad.zip](https://github.com/j0zzz/JoeQuake/files/11866142/bad.zip) into speedrunner jam dir.
4. Start Quake with speedrunner game as the `-game`.
5. Bind "load bad" to a key.
6. Start a game, hit the bound key.
7. Hit the bound key when the in-game clock hits 9.5 seconds (approx).
8. Repeat previous step until game locks up or segfaults.

I usually hit it within 5 attempts, and I don't see it at all with this fix applied. I wasn't able to reproduce it with wine but I think its worth fixing in any case since the issue could crop up in other ways on windows.
