### PR TITLE
fix potential crash after loading of saved game

### DIFF
--- a/trunk/host_cmd.c
+++ b/trunk/host_cmd.c
@@ -703,6 +703,10 @@ void Host_Loadgame_f (void)
 		entnum++;
 	}
 
+	// Free edicts allocated during map loading but no longer used after restoring saved game state
+	for (i = entnum; i < sv.num_edicts; i++)
+		ED_Free(EDICT_NUM(i));
+
 	sv.num_edicts = entnum;
 	sv.time = time;
 


### PR DESCRIPTION
This is a port of alexey.lysiuk's fix for QuakeSpasm:

https://github.com/sezero/quakespasm/pull/75/commits/5dd8f36a13d4366fff1e64add708d1b77e9ffff3
https://github.com/sezero/quakespasm/pull/75

Observed by me in ironwail and also JQ reloading a savegame at the start of e1m6:

https://github.com/andrei-drexler/ironwail/issues/242