### PR TITLE
Avoid occasional 3s pause on restarting level

### DIFF
--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -176,6 +176,8 @@ This is also called on Host_Error, so it shouldn't cause any errors
 */
 void CL_Disconnect (void)
 {
+	qboolean was_loopback;
+
 // stop sounds (especially looping!)
 	S_StopAllSounds (true);
 	
@@ -201,11 +203,27 @@ void CL_Disconnect (void)
 		MSG_WriteByte (&cls.message, clc_disconnect);
 		NET_SendUnreliableMessage (cls.netcon, &cls.message);
 		SZ_Clear (&cls.message);
+		was_loopback = (cls.netcon && !cls.netcon->disconnected && cls.netcon->driver == 0);
 		NET_Close (cls.netcon);
 
 		cls.state = ca_disconnected;
 		if (sv.active)
+		{
+			if (was_loopback
+				&& svs.clients->active
+				&& svs.clients->netconnection
+				&& svs.clients->netconnection->driver == 0)
+			{
+				// If this is a loopback connection and there is data ready to
+				// be sent to the client, then the data will never be sent since
+				// we just closed the socket (`NET_Close` above), and therefore
+				// `Host_ShutdownServer` will always hang for three seconds.
+				//
+				// Avoid this by just discarding the pending message.
+				SZ_Clear (&svs.clients->message);
+			}
 			Host_ShutdownServer (false);
+		}
 	}
 
 	cls.demoplayback = cls.timedemo = false;


### PR DESCRIPTION
Host_ShutdownServer has some logic for flushing outgoing messages to the client.  But this will always fail for the loopback connection since the client has already shut down its socket, meaning that if there is data queued then it will always wait the full 3 seconds.

This manifests itself as an occasional 3 second pause typically seen by spamming binds for "record <demoname> <levelname>", which players sometimes do.