### PR TITLE
support numpad on SDL

### DIFF
--- a/trunk/in_sdl.c
+++ b/trunk/in_sdl.c
@@ -146,6 +146,24 @@ static inline int IN_SDL2_ScancodeToQuakeKey(SDL_Scancode scancode)
 	case SDL_SCANCODE_PAUSE: return K_PAUSE;
 	case SDL_SCANCODE_CAPSLOCK: return K_CAPSLOCK;
 
+	case SDL_SCANCODE_NUMLOCKCLEAR: return KP_NUMLOCK;
+	case SDL_SCANCODE_KP_DIVIDE: return KP_SLASH;
+	case SDL_SCANCODE_KP_MULTIPLY: return KP_STAR;
+	case SDL_SCANCODE_KP_7: return KP_HOME;
+	case SDL_SCANCODE_KP_8: return KP_UPARROW;
+	case SDL_SCANCODE_KP_9: return KP_PGUP;
+	case SDL_SCANCODE_KP_MINUS: return KP_MINUS;
+	case SDL_SCANCODE_KP_4: return KP_LEFTARROW;
+	case SDL_SCANCODE_KP_5: return KP_5;
+	case SDL_SCANCODE_KP_6: return KP_RIGHTARROW;
+	case SDL_SCANCODE_KP_PLUS: return KP_PLUS;
+	case SDL_SCANCODE_KP_1: return KP_END;
+	case SDL_SCANCODE_KP_2: return KP_DOWNARROW;
+	case SDL_SCANCODE_KP_3: return KP_PGDN;
+	case SDL_SCANCODE_KP_0: return KP_INS;
+	case SDL_SCANCODE_KP_PERIOD: return KP_DEL;
+	case SDL_SCANCODE_KP_ENTER: return KP_ENTER;
+
 	default: return 0;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/j0zzz/JoeQuake/issues/118

I don't have a numpad available, but I tested it with `xdotool` on Linux.  Worth testing on windows with a real numpad if anyone has the equipment for it.

The following script might be handy for testing:

```
bind KP_NUMLOCK "echo KP_NUMLOCK pressed"
bind KP_SLASH "echo KP_SLASH pressed"
bind KP_STAR "echo KP_STAR pressed"
bind KP_HOME "echo KP_HOME pressed"
bind KP_UPARROW "echo KP_UPARROW pressed"
bind KP_PGUP "echo KP_PGUP pressed"
bind KP_MINUS "echo KP_MINUS pressed"
bind KP_LEFTARROW "echo KP_LEFTARROW pressed"
bind KP_5 "echo KP_5 pressed"
bind KP_RIGHTARROW "echo KP_RIGHTARROW pressed"
bind KP_PLUS "echo KP_PLUS pressed"
bind KP_END "echo KP_END pressed"
bind KP_DOWNARROW "echo KP_DOWNARROW pressed"
bind KP_PGDN "echo KP_PGDN pressed"
bind KP_INS "echo KP_INS pressed"
bind KP_DEL "echo KP_DEL pressed"
bind KP_ENTER "echo KP_ENTER pressed"
```