### PR TITLE
do not register _windowed_mouse twice

### DIFF
--- a/trunk/in_sdl.c
+++ b/trunk/in_sdl.c
@@ -222,7 +222,6 @@ void Force_CenterView_f (void)
 void IN_Init (void)
 {
 	Cvar_Register (&m_filter);
-	Cvar_Register (&_windowed_mouse);
 
 	Cmd_AddCommand ("force_centerview", Force_CenterView_f);
 }


### PR DESCRIPTION
Noticed by @Flecked42 

![image](https://github.com/j0zzz/JoeQuake/assets/1709642/8567d803-8095-4b2a-9e48-2f85b5d292c5)

This was being registered in `in_sdl.c` and `vid_sdl.c`.  I don't think it had any effect other than the warning above.