### PR TITLE
add string conversion for demoparse errors

### DIFF
--- a/trunk/ghost/demoparse.c
+++ b/trunk/ghost/demoparse.c
@@ -987,6 +987,21 @@ static const char *dp_err_strings[] = {
 };
 
 
+const char *
+DP_StrError(dp_err_t rc)
+{
+    static char buf[512];
+
+    if (rc < 0 || rc >= sizeof(dp_err_strings) / sizeof(char *)) {
+        Q_snprintfz(buf, sizeof(buf), "Unknown error (%d)", rc);
+    } else {
+        Q_snprintfz(buf, sizeof(buf), "%s (%d)", dp_err_strings[rc], rc);
+    }
+
+    return buf;
+}
+
+
 dp_err_t
 DP_ReadDemo(dp_callbacks_t *callbacks, void *callback_ctx)
 {

--- a/trunk/ghost/demoparse.h
+++ b/trunk/ghost/demoparse.h
@@ -85,6 +85,7 @@ typedef struct {
 
 
 dp_err_t DP_ReadDemo(dp_callbacks_t *callbacks, void *callback_ctx);
+const char *DP_StrError(dp_err_t rc);
 
 
 #endif /* __DEMOPARSE_H */

--- a/trunk/ghost/ghostparse.c
+++ b/trunk/ghost/ghostparse.c
@@ -411,7 +411,7 @@ Ghost_ReadDemoNoChain (FILE *demo_file, ghost_info_t *ghost_info,
                 ok = false;
             }
         } else if (dprc != DP_ERR_SUCCESS) {
-            Con_Printf("Error parsing demo: %u\n", dprc);
+            Con_Printf("Error parsing demo: %s\n", DP_StrError(dprc));
             ok = false;
         } else if (!pctx.map_found) {
             Con_Printf("Map %s not found in demo\n", expected_map_name);


### PR DESCRIPTION
Noticed this branch I made a while ago and never merged.  It gives slightly more helpful error messages when the ghost code parses a bad demo.