### PR TITLE
Ghost instant load

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -956,11 +956,10 @@ ctrl-shift-enter to remove the ghost.
 
 #### Commands
 
-- `ghost <demo-file>`:  Add ghost from the given demo file.  The ghost will be
-  loaded on next map load.  With no arguments it will show the current ghost's
-  demo file, if any.  Only one ghost may be added at a time.
-- `ghost_remove`: Remove the current ghost, if any is added.  The change will
-  take effect on next map load.
+- `ghost <demo-file>`:  Load ghost from the given demo file.  With no arguments
+  it will show information about the current ghost, if any.  Only one ghost may
+  be added at a time.
+- `ghost_remove`: Remove the current ghost, if any is added.
 - `ghost_shift <t>`: Shift the ghost to be the given number of seconds infront
   of the player.  Useful if you lose the ghost but you still want to see its
   route.
@@ -981,7 +980,8 @@ ctrl-shift-enter to remove the ghost.
 
 #### Marathon split times
 
-When a ghost is loaded a split time is printed to the console at the end of each
-level.  If a marathon demo is loaded as the ghost, and the player is also
-running a marathon, then split times for each level are shown.  Splits are also
-shown when playing a demo with a ghost loaded.
+When a ghost is loaded a split time is shown on the intermission screen and,
+printed to the console at the end of each level.  If a marathon demo is loaded
+as the ghost, and the player is also running a marathon, then split times for
+each level are shown.  Splits are also shown when playing a demo with a ghost
+loaded.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -980,7 +980,7 @@ ctrl-shift-enter to remove the ghost.
 
 #### Marathon split times
 
-When a ghost is loaded a split time is shown on the intermission screen and,
+When a ghost is loaded a split time is shown on the intermission screen and
 printed to the console at the end of each level.  If a marathon demo is loaded
 as the ghost, and the player is also running a marathon, then split times for
 each level are shown.  Splits are also shown when playing a demo with a ghost

--- a/docs/_includes/subfeatures/ghost-recording.md
+++ b/docs/_includes/subfeatures/ghost-recording.md
@@ -11,11 +11,10 @@ ctrl-shift-enter to remove the ghost.
 
 #### Commands
 
-- `ghost <demo-file>`:  Add ghost from the given demo file.  The ghost will be
-  loaded on next map load.  With no arguments it will show the current ghost's
-  demo file, if any.  Only one ghost may be added at a time.
-- `ghost_remove`: Remove the current ghost, if any is added.  The change will
-  take effect on next map load.
+- `ghost <demo-file>`:  Load ghost from the given demo file.  With no arguments
+  it will show information about the current ghost, if any.  Only one ghost may
+  be added at a time.
+- `ghost_remove`: Remove the current ghost, if any is added.
 - `ghost_shift <t>`: Shift the ghost to be the given number of seconds infront
   of the player.  Useful if you lose the ghost but you still want to see its
   route.
@@ -36,7 +35,8 @@ ctrl-shift-enter to remove the ghost.
 
 #### Marathon split times
 
-When a ghost is loaded a split time is printed to the console at the end of each
-level.  If a marathon demo is loaded as the ghost, and the player is also
-running a marathon, then split times for each level are shown.  Splits are also
-shown when playing a demo with a ghost loaded. 
+When a ghost is loaded a split time is shown on the intermission screen and,
+printed to the console at the end of each level.  If a marathon demo is loaded
+as the ghost, and the player is also running a marathon, then split times for
+each level are shown.  Splits are also shown when playing a demo with a ghost
+loaded.

--- a/docs/_includes/subfeatures/ghost-recording.md
+++ b/docs/_includes/subfeatures/ghost-recording.md
@@ -35,7 +35,7 @@ ctrl-shift-enter to remove the ghost.
 
 #### Marathon split times
 
-When a ghost is loaded a split time is shown on the intermission screen and,
+When a ghost is loaded a split time is shown on the intermission screen and
 printed to the console at the end of each level.  If a marathon demo is loaded
 as the ghost, and the player is also running a marathon, then split times for
 each level are shown.  Splits are also shown when playing a demo with a ghost

--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -564,6 +564,8 @@ void CL_ParseServerInfo (void)
 	COM_StripExtension (COM_SkipPath(model_precache[1]), tempname);
 	R_PreMapLoad (tempname);
 
+	Ghost_Load();
+
 // now we try to load everything else until a cache allocation fails
 	for (i = 1 ; i < nummodels ; i++)
 	{

--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -564,8 +564,6 @@ void CL_ParseServerInfo (void)
 	COM_StripExtension (COM_SkipPath(model_precache[1]), tempname);
 	R_PreMapLoad (tempname);
 
-	Ghost_Load(tempname);
-
 // now we try to load everything else until a cache allocation fails
 	for (i = 1 ; i < nummodels ; i++)
 	{

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -269,7 +269,6 @@ static qboolean first_update;
 static qboolean Ghost_SetForLevel (void)
 {
     int i;
-    FILE *demo_file;
     ghost_level_t *level;
 
     if (ghost_demo_path[0] == '\0') {

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -209,6 +209,7 @@ static void Ghost_UpdateMarathon (void)
 
 static void Ghost_PrintMarathonSplits (void)
 {
+    float split, total_split;
     int i;
     ghost_marathon_level_t *gml;
     ghost_marathon_info_t *gmi = &ghost_marathon_info;
@@ -220,13 +221,16 @@ static void Ghost_PrintMarathonSplits (void)
                    "\x9d\x9e\x9e\x9e\x9e\x9e\x9e\x9e\x9e\x9e\x9e\x9f "
                    "\x9d\x9e\x9e\x9e\x9e\x9e\x9e\x9f "
                    "\x9d\x9e\x9e\x9e\x9e\x9e\x9e\x9f\n");
+        total_split = 0.0f;
         for (i = gmi->ghost_start; i < gmi->num_levels; i++) {
             gml = &gmi->levels[i];
+            split = gml->player_time - gml->ghost_time;
+            total_split += split;
             Con_Printf("  %-10s %12s %+8.2f %+8.2f\n",
                        gml->map_name,
                        GetPrintedTime(gml->player_time),
-                       (gml->player_time - gml->ghost_time),
-                       gmi->total_split);
+                       split,
+                       total_split);
         }
     }
 }
@@ -755,10 +759,10 @@ void Ghost_Finish (void)
             gml->player_time = cl.mtime[0];
         }
 
-        Ghost_UpdateMarathon();
-        Ghost_PrintMarathonSplits();
-    } else {
-        gmi->num_levels = 0;
+        if (ghost_demo_path[0]) {
+            Ghost_UpdateMarathon();
+            Ghost_PrintMarathonSplits();
+        }
     }
 }
 
@@ -876,7 +880,7 @@ static void Ghost_Command_f (void)
 
     DZip_Cleanup(&ghost_dz_ctx);
 
-    if (sv.active || cls.demoplayback) {
+    if (ok && (sv.active || cls.demoplayback)) {
         Ghost_UpdateMarathon();
         Ghost_PrintMarathonSplits();
     }

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -245,7 +245,6 @@ static void Ghost_Load (void)
     ghost_level_t *level;
 
     ghost_records = NULL;
-    ghost_num_records = 0;
 
     if (ghost_demo_path[0] == '\0') {
         if (ghost_info != NULL) {
@@ -904,6 +903,7 @@ static void Ghost_RemoveCommand_f (void)
     } else {
         Ghost_Free(&ghost_info);
         ghost_demo_path[0] = '\0';
+        ghost_records = NULL;
     }
 }
 

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -184,7 +184,7 @@ static void Ghost_UpdateMarathon (void)
 
     gmi->valid = true;
     gmi->total_split = 0.0f;
-    for (i = 0; i < cls.marathon_level; i++) {
+    for (i = 0; i < cls.marathon_level && i < MAX_MARATHON_LEVELS; i++) {
         gml = &gmi->levels[i];
 
         gml->ghost_time = -1.0f;
@@ -220,7 +220,9 @@ static void Ghost_PrintMarathonSplits (void)
                    "\x9d\x9e\x9e\x9e\x9e\x9e\x9e\x9f "
                    "\x9d\x9e\x9e\x9e\x9e\x9e\x9e\x9f\n");
         total_split = 0.0f;
-        for (i = gmi->ghost_start; i < cls.marathon_level; i++) {
+        for (i = gmi->ghost_start;
+                i < cls.marathon_level && i < MAX_MARATHON_LEVELS;
+                i++) {
             gml = &gmi->levels[i];
             split = gml->player_time - gml->ghost_time;
             total_split += split;
@@ -699,6 +701,9 @@ static void Ghost_DrawIntermissionTimes (void)
 
     total = gmi->total_split;
     for (i = cls.marathon_level - 1; i >= 0; i--) {
+        if (i >= MAX_MARATHON_LEVELS) {
+            continue;
+        }
         y -= 2 * size;
         if (y <= min_y) {
             break;

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -836,6 +836,7 @@ static void Ghost_Command_f (void)
             Ghost_Free(&ghost_info);
         }
         ok = Ghost_ReadDemo(demo_file, &ghost_info);
+        // file is now closed.
     }
 
     if (ok) {
@@ -847,9 +848,6 @@ static void Ghost_Command_f (void)
         ghost_demo_path[0] = '\0';
     }
 
-    if (demo_file) {
-        fclose(demo_file);
-    }
     DZip_Cleanup(&ghost_dz_ctx);
 }
 

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -165,7 +165,7 @@ Ghost_OpenDemoOrDzip (const char *demo_path)
         Q_strlcpy(demo_path_with_ext, demo_path, MAX_OSPATH);
         COM_DefaultExtension (demo_path_with_ext, ".dem");
         if (COM_FOpenFile (demo_path_with_ext, &demo_file) == -1) {
-            Con_Printf("cannot find demo %s", demo_path_with_ext);
+            Con_Printf("cannot find demo %s\n", demo_path_with_ext);
             demo_file = NULL;
         }
     }

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -261,7 +261,7 @@ static void Ghost_Load (void)
             break;
         }
     }
-    if (i == ghost_info->num_levels) {
+    if (i >= ghost_info->num_levels) {
         Con_Printf("Map %s not found in ghost demo\n", ghost_map_name);
         return;
     }

--- a/trunk/ghost/ghost.h
+++ b/trunk/ghost/ghost.h
@@ -35,7 +35,7 @@ typedef struct {
 } ghost_color_info_t;
 
 extern char         ghost_demo_path[MAX_OSPATH];
-extern entity_t		*ghost_entity;
+extern entity_t		ghost_entity;
 extern ghost_color_info_t ghost_color_info[GHOST_MAX_CLIENTS];
 
 

--- a/trunk/ghost/ghost.h
+++ b/trunk/ghost/ghost.h
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define GHOST_MAX_CLIENTS   8
 
+void Ghost_Load (void);
 void Ghost_Draw (void);
 void Ghost_DrawGhostTime (qboolean intermission);
 void Ghost_Init (void);

--- a/trunk/ghost/ghost.h
+++ b/trunk/ghost/ghost.h
@@ -23,7 +23,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define GHOST_MAX_CLIENTS   8
 
-void Ghost_Load (const char *map_name);
 void Ghost_Draw (void);
 void Ghost_DrawGhostTime (qboolean intermission);
 void Ghost_Init (void);

--- a/trunk/ghost/ghost_private.h
+++ b/trunk/ghost/ghost_private.h
@@ -26,6 +26,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 
+#define GHOST_MAX_LEVELS     128
+#define GHOST_MAP_NAME_SIZE  64
+
+
 typedef enum {
     GHOST_MODEL_PLAYER = 0,
     GHOST_MODEL_EYES,
@@ -44,17 +48,26 @@ typedef struct {
 
 
 typedef struct {
+    char map_name[GHOST_MAP_NAME_SIZE];
+
     char client_names[GHOST_MAX_CLIENTS][MAX_SCOREBOARDNAME];
     byte client_colors[GHOST_MAX_CLIENTS];
     float finish_time;
     ghostrec_t *records;
     int num_records;
     int model_indices[GHOST_MODEL_COUNT];
+} ghost_level_t;
+
+
+typedef struct {
+    ghost_level_t levels[GHOST_MAX_LEVELS];
+    int num_levels;
 } ghost_info_t;
+
 
 extern const char *ghost_model_paths[GHOST_MODEL_COUNT];
 
-qboolean Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info,
-                         const char *expected_map_name);
+qboolean Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info);
+void Ghost_Free (ghost_info_t *ghost_info);
 
 #endif /* __GHOST_PRIVATE */

--- a/trunk/ghost/ghost_private.h
+++ b/trunk/ghost/ghost_private.h
@@ -67,7 +67,7 @@ typedef struct {
 
 extern const char *ghost_model_paths[GHOST_MODEL_COUNT];
 
-qboolean Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info);
-void Ghost_Free (ghost_info_t *ghost_info);
+qboolean Ghost_ReadDemo (FILE *demo_file, ghost_info_t **ghost_info);
+void Ghost_Free (ghost_info_t **ghost_info);
 
 #endif /* __GHOST_PRIVATE */

--- a/trunk/ghost/ghostparse.c
+++ b/trunk/ghost/ghostparse.c
@@ -24,63 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 
 #define MAX_CHAINED_DEMOS   64
-
-
-/*
- * RECORD LISTS
- *
- * Records are pushed onto a linked list before being compressed into a dense
- * array.
- */
-
-typedef struct ghostreclist_s {
-    ghostrec_t rec;
-    struct ghostreclist_s *next;
-} ghostreclist_t;
-
-
-static void Ghost_Append(ghostreclist_t ***next_ptr, ghostrec_t *rec)
-{
-    ghostreclist_t *new_entry = Hunk_AllocName(sizeof(ghostreclist_t), "ghost_list_element");
-
-    new_entry->rec = *rec;
-    new_entry->next = NULL;
-    **next_ptr = new_entry;
-    *next_ptr = &new_entry->next;
-}
-
-
-static int Ghost_ListLen(ghostreclist_t *list)
-{
-    int count = 0;
-
-    while (list != NULL) {
-        list = list->next;
-        count ++;
-    }
-
-    return count;
-}
-
-
-static void Ghost_ListToArray(ghostreclist_t *list, ghostrec_t **records_out,
-                              int *num_records_out)
-{
-    ghostrec_t *records;
-    int num_records;
-    int record_num;
-
-    num_records = Ghost_ListLen(list);
-    records = Hunk_AllocName(num_records * sizeof(ghostrec_t),
-                             "ghostrecords");
-
-    for (record_num = 0; list != NULL; list = list->next, record_num++) {
-        records[record_num] = list->rec;
-    }
-
-    *records_out = records;
-    *num_records_out = num_records;
-}
+#define RECORD_REALLOC_LOG2     9   // 512 records per chunk, approx 7 seconds
 
 
 /*
@@ -91,27 +35,23 @@ static void Ghost_ListToArray(ghostreclist_t *list, ghostrec_t **records_out,
 
 
 typedef struct {
+    ghost_info_t *ghost_info;
+    ghost_level_t *level;
+
     int view_entity;
-    ghostreclist_t **next_ptr;
     ghostrec_t rec;
-    qboolean map_found;
     qboolean updated;  // record changed since last append
 
     FILE *demo_file;
 
     int model_num;
-    const char *expected_map_name;
 
     vec3_t baseline_origin;
     vec3_t baseline_angle;
     int baseline_frame;
     int baseline_model;
 
-    char (*client_names)[MAX_SCOREBOARDNAME];
-    byte *client_colors;
-    float finish_time;
     char next_demo_path[MAX_OSPATH];
-    int model_indices[GHOST_MODEL_COUNT];
 } ghost_parse_ctx_t;
 
 
@@ -122,7 +62,6 @@ Ghost_Read_cb (void *dest, unsigned int size, void *ctx)
     return fread (dest, size, 1, pctx->demo_file) != 0;
 }
 
-
 static dp_cb_response_t
 Ghost_ServerInfoModel_cb (const char *model, void *ctx)
 {
@@ -131,22 +70,25 @@ Ghost_ServerInfoModel_cb (const char *model, void *ctx)
     int i;
 
     if (pctx->model_num == 0) {
-        if (pctx->map_found) {
-            // Hit a new server info message after already having found one with
-            // the map name we want.  This means that we have fully parsed the
-            // part of the demo that we need for the ghost.
+        // Just encountered a new server info.  Move to the next level.
+        pctx->ghost_info->num_levels ++;
+        if (pctx->ghost_info->num_levels == GHOST_MAX_LEVELS) {
             return DP_CBR_STOP;
         }
-		Q_strncpyz(map_name, (char *)model, sizeof(map_name));  // truncate to MAX_OSPATH
-        COM_StripExtension(COM_SkipPath(map_name), map_name);
-        if (!strcmp(map_name, pctx->expected_map_name)) {
-            pctx->map_found = true;
-        }
+        pctx->level = &pctx->ghost_info->levels[pctx->ghost_info->num_levels];
+        memset(pctx->level, 0, sizeof(ghost_level_t));
+
+        Q_strncpyz(pctx->level->map_name, (char *)model,
+                   sizeof(pctx->level->map_name));
+        COM_StripExtension(COM_SkipPath(pctx->level->map_name),
+                           pctx->level->map_name);
+        pctx->level->finish_time = -1.0f;
+        pctx->view_entity = 0;
     }
 
     for (i = 0; i < GHOST_MODEL_COUNT; i++) {
         if (strcmp(model, ghost_model_paths[i]) == 0) {
-            pctx->model_indices[i] = pctx->model_num + 1;
+            pctx->level->model_indices[i] = pctx->model_num + 1;
         }
     }
 
@@ -172,10 +114,6 @@ Ghost_Time_cb (float time, void *ctx)
 {
     ghost_parse_ctx_t *pctx = ctx;
 
-    if (!pctx->map_found) {
-        // Still scanning for map, so skip to next packet.
-        return DP_CBR_SKIP_PACKET;
-    }
     pctx->rec.time = time;
     return DP_CBR_CONTINUE;
 }
@@ -186,10 +124,6 @@ Ghost_SetView_cb (int entity_num, void *ctx)
 {
     ghost_parse_ctx_t *pctx = ctx;
 
-    if (!pctx->map_found) {
-        // Still scanning for map, so skip to next packet.
-        return DP_CBR_SKIP_PACKET;
-    }
     pctx->view_entity = entity_num;
     return DP_CBR_CONTINUE;
 }
@@ -200,11 +134,6 @@ Ghost_Baseline_cb (int entity_num, vec3_t origin, vec3_t angle, int frame,
                    int model, void *ctx)
 {
     ghost_parse_ctx_t *pctx = ctx;
-
-    if (!pctx->map_found) {
-        // Still scanning for map, so skip to next packet.
-        return DP_CBR_SKIP_PACKET;
-    }
 
     if (pctx->view_entity == -1) {
         Con_Printf("Baseline receieved but entity num not set\n");
@@ -271,12 +200,28 @@ Ghost_Update_cb(int entity_num, vec3_t origin, vec3_t angle, byte origin_bits,
 }
 
 
+static void
+Ghost_Append(ghost_level_t *level, ghostrec_t *rec)
+{
+    int num_chunks;
+
+    if (level->num_records & ((1 << RECORD_REALLOC_LOG2) - 1) == 0)
+    {
+        num_chunks = (level->num_records >> RECORD_REALLOC_LOG2) + 1;
+        level->records = Q_realloc(level->records,
+                                   sizeof(ghostrec_t) * num_chunks);
+    }
+    level->records[level->num_records] = *rec;
+    level->num_records ++;
+}
+
+
 static dp_cb_response_t
 Ghost_PacketEnd_cb (void *ctx)
 {
     ghost_parse_ctx_t *pctx = ctx;
     if (pctx->updated) {
-        Ghost_Append(&pctx->next_ptr, &pctx->rec);
+        Ghost_Append(pctx->level, &pctx->rec);
         pctx->updated = false;
     }
     return DP_CBR_CONTINUE;
@@ -288,16 +233,11 @@ Ghost_Intermission_cb (void *ctx)
 {
     ghost_parse_ctx_t *pctx = ctx;
 
-    if (!pctx->map_found) {
-        // Still scanning for map, so skip to next packet.
-        return DP_CBR_SKIP_PACKET;
+    if (pctx->level->finish_time <= 0) {
+        pctx->level->finish_time = pctx->rec.time;
     }
 
-    if (pctx->finish_time <= 0) {
-        pctx->finish_time = pctx->rec.time;
-    }
-
-    return DP_CBR_STOP;
+    return DP_CBR_SKIP_PACKET;
 }
 
 
@@ -306,13 +246,9 @@ Ghost_UpdateName_cb (int client_num, const char *name, void *ctx)
 {
     ghost_parse_ctx_t *pctx = ctx;
 
-    if (!pctx->map_found) {
-        // Still scanning for map, so skip to next packet.
-        return DP_CBR_SKIP_PACKET;
-    }
-
     if (client_num >= 0 && client_num < GHOST_MAX_CLIENTS) {
-        Q_strncpyz(pctx->client_names[client_num], (char *)name, MAX_SCOREBOARDNAME);
+        Q_strncpyz(pctx->level->client_names[client_num], (char *)name,
+                   MAX_SCOREBOARDNAME);
     }
 
     return DP_CBR_CONTINUE;
@@ -346,13 +282,8 @@ Ghost_UpdateColors_cb(byte client_num, byte colors, void* ctx)
 {
     ghost_parse_ctx_t *pctx = ctx;
 
-    if (!pctx->map_found) {
-        // Still scanning for map, so skip to next packet.
-        return DP_CBR_SKIP_PACKET;
-    }
-
     if (client_num >= 0 && client_num < GHOST_MAX_CLIENTS) {
-        pctx->client_colors[client_num] = colors;
+        pctx->level->client_colors[client_num] = colors;
     }
 
     return DP_CBR_CONTINUE;
@@ -361,11 +292,9 @@ Ghost_UpdateColors_cb(byte client_num, byte colors, void* ctx)
 
 static qboolean
 Ghost_ReadDemoNoChain (FILE *demo_file, ghost_info_t *ghost_info,
-                       const char *expected_map_name,
                        char *next_demo_path)
 {
     qboolean ok = true;
-    ghostreclist_t *list = NULL;
     dp_err_t dprc;
     dp_callbacks_t callbacks = {
         .read = Ghost_Read_cb,
@@ -384,50 +313,30 @@ Ghost_ReadDemoNoChain (FILE *demo_file, ghost_info_t *ghost_info,
         .update_colors = Ghost_UpdateColors_cb,
     };
     ghost_parse_ctx_t pctx = {
-        .view_entity = -1,
-        .next_ptr = &list,
-        .expected_map_name = expected_map_name,
-        .client_names = ghost_info->client_names,
-        .client_colors = ghost_info->client_colors,
-        .finish_time = -1,
-        .model_indices = {0},
+        .model_num = 0,
+        .demo_file = demo_file,
+        .updated = false,
     };
-
-    pctx.demo_file = demo_file;
 
     if (ok) {
         next_demo_path[0] = '\0';
         dprc = DP_ReadDemo(&callbacks, &pctx);
         if (dprc == DP_ERR_CALLBACK_STOP) {
-            if (pctx.finish_time > 0) {
-                // Map was found, and intermission reached.
+            if (pctx.ghost_info->num_levels == GHOST_MAX_LEVELS) {
+                Con_Printf("Demo contains more than %d maps, ghost has been "
+                           "truncated\n",
+                           GHOST_MAX_LEVELS);
                 ok = true;
-            } else if (pctx.next_demo_path[0] && !pctx.map_found) {
-                // Map not found, but there's another .dem file in the chain.
+            } else if (pctx.next_demo_path[0]) {
+                // There's another .dem file in the chain.
                 Q_strlcpy(next_demo_path, pctx.next_demo_path, MAX_OSPATH);
                 ok = true;
             } else {
-                // Errors from callbacks print their own error messages.
+                // Error already printed.
                 ok = false;
             }
         } else if (dprc != DP_ERR_SUCCESS) {
             Con_Printf("Error parsing demo: %s\n", DP_StrError(dprc));
-            ok = false;
-        } else if (!pctx.map_found) {
-            Con_Printf("Map %s not found in demo\n", expected_map_name);
-            ok = false;
-        }
-    }
-
-    if (ok && pctx.finish_time > 0) {
-        Ghost_ListToArray(list, &ghost_info->records, &ghost_info->num_records);
-        ghost_info->finish_time = pctx.finish_time;
-        memcpy(ghost_info->model_indices,
-               pctx.model_indices,
-               sizeof(pctx.model_indices));
-
-        if (ghost_info->num_records == 0) {
-            Con_Printf("ERROR: No records found in demo\n");
             ok = false;
         }
     }
@@ -449,16 +358,14 @@ Ghost_ReadDemoNoChain (FILE *demo_file, ghost_info_t *ghost_info,
 
 
 qboolean
-Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info,
-                const char *expected_map_name)
+Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info)
 {
     qboolean ok = true;
     char next_demo_path[MAX_OSPATH];
     int num_demos_searched = 0;
 
     while (ok && demo_file != NULL && num_demos_searched < MAX_CHAINED_DEMOS) {
-        ok = Ghost_ReadDemoNoChain (demo_file, ghost_info,
-                                    expected_map_name, next_demo_path);
+        ok = Ghost_ReadDemoNoChain (demo_file, ghost_info, next_demo_path);
         if (ok) {
             if (next_demo_path[0] != '\0') {
                 if (COM_FOpenFile (next_demo_path, &demo_file) == -1) {
@@ -473,7 +380,6 @@ Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info,
             }
         }
     }
-    Hunk_HighMark();
 
     if (num_demos_searched == MAX_CHAINED_DEMOS) {
         // Best to have a limit in case we have looped demos.
@@ -482,6 +388,21 @@ Ghost_ReadDemo (FILE *demo_file, ghost_info_t *ghost_info,
         ok = false;
     }
 
+    if (!ok) {
+        Ghost_Free(ghost_info);
+    }
+
     return ok;
 }
 
+
+void
+Ghost_Free (ghost_info_t *ghost_info)
+{
+    int level_idx;
+
+    for (level_idx = 0; level_idx < ghost_info->num_levels; level_idx ++) {
+        free(ghost_info->levels[level_idx].records);
+        ghost_info->levels[level_idx].records = NULL;
+    }
+}

--- a/trunk/ghost/ghostparse.c
+++ b/trunk/ghost/ghostparse.c
@@ -326,7 +326,7 @@ Ghost_ReadDemoNoChain (FILE *demo_file, ghost_info_t *ghost_info,
         if (dprc == DP_ERR_CALLBACK_STOP) {
             if (pctx.ghost_info->num_levels > GHOST_MAX_LEVELS) {
                 Con_Printf("Demo contains more than %d maps, ghost has been "
-                           "truncated",
+                           "truncated\n",
                            GHOST_MAX_LEVELS);
                 pctx.ghost_info->num_levels = GHOST_MAX_LEVELS;
                 ok = true;

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -1693,7 +1693,7 @@ void R_DrawAliasModel (entity_t *ent)
 		extern int player_32bit_skins[14];
 		extern qboolean player_32bit_skins_loaded;
 
-		if (ent == ghost_entity)
+		if (ent == &ghost_entity)
 		{
 			i = 1;	// currently only supporting 1 ghost player
 

--- a/trunk/gl_rmisc.c
+++ b/trunk/gl_rmisc.c
@@ -134,7 +134,7 @@ void R_TranslatePlayerSkin (int playernum, qboolean ghost)
 	}
 
 	// locate the original skin pixels
-	currententity = ghost ? ghost_entity : &cl_entities[1 + playernum];
+	currententity = ghost ? &ghost_entity : &cl_entities[1 + playernum];
 	if (!(model = currententity->model))
 		return;		// player doesn't have a model yet
 	if (model->type != mod_alias)


### PR DESCRIPTION
Changes to make ghosts load immediately after running the `ghost` command.  This means you can switch ghosts mid-level and mid-marathon.   Before switching the ghost mid-marathon would (I think) end up with a mix of the two ghost demos in the split times which was confusing, whereas now the marathon splits are fully updated to the current ghost.  This PR also means that the ghost info shown at the bottom of the intermission screen is accurate[^1], whereas before the bottom line would immediately update but the split times would be for the old ghost.

To achieve this I switched away from re-loading the ghost demo file at the start of each level.  Instead I load every level of the demo immediately at the ghost command, alloc'ing with `Q_malloc` / `Q_realloc`.  Muty's 57 minute NH run loads in a few seconds on my laptop (most of the time is spent undzipping) and eats about 10MB of RAM, which is probably acceptable?

[^1]: well, the ghost summary shown on the intermission screen doesn't handle multi .dem pak marathons yet, so in this case the info will not be accurate.