### PR TITLE
Intermission screen finish time decimals

### DIFF
--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -580,6 +580,11 @@ Possible values are between `0.0` (fully transparent) and `1.0` (fully opaque).
 Sets the type of screenshot image, `jpg` by default.
 Can be `tga`, `png` or `[jpeg|jpg]`.
 
+##### `scr_precisetime`
+
+Show two decimal places of precision on the intermission screen time, `0` by
+default.
+
 #### Console
 
 ##### `gl_conalpha`

--- a/trunk/sbar.c
+++ b/trunk/sbar.c
@@ -69,7 +69,7 @@ int	sbar_xofs;
 cvar_t	scr_centersbar = {"scr_centersbar", "1"};
 cvar_t	scr_sbarscale_amount = { "scr_sbarscale_amount", "2" };
 cvar_t	scr_scorebarmode = { "scr_scorebarmode", "0" };
-cvar_t	scr_timeprecision = { "scr_timeprecision", "2" };
+cvar_t	scr_precisetime = { "scr_precisetime", "0" };
 
 /*
 ===============
@@ -275,7 +275,7 @@ void Sbar_Init (void)
 	Cvar_Register (&scr_centersbar);
 	Cvar_Register (&scr_sbarscale_amount);
 	Cvar_Register(&scr_scorebarmode);
-	Cvar_Register(&scr_timeprecision);
+	Cvar_Register(&scr_precisetime);
 
 	Cmd_AddCommand ("+showscores", Sbar_ShowScores);
 	Cmd_AddCommand ("-showscores", Sbar_DontShowScores);
@@ -1465,9 +1465,10 @@ void Sbar_IntermissionOverlay (void)
 	double frac;
 	char fracstring[9];
 
-	precision = (int)scr_timeprecision.value;
-	if (precision > 5)
-		precision = 5;
+	if (scr_precisetime.value)
+		precision = 2;
+	else
+		precision = 0;
 
 	scr_copyeverything = 1;
 	scr_fullupdate = 0;

--- a/trunk/sbar.c
+++ b/trunk/sbar.c
@@ -1461,8 +1461,8 @@ void Sbar_IntermissionOverlay (void)
 	mpic_t	*pic;
 	int		dig, num, xofs, pos, i;
 	int precision;
-	float remainder;
 	float	scale;
+	char fracstring[8];
 
 	precision = (int)scr_timeprecision.value;
 	if (precision > 5)
@@ -1500,15 +1500,12 @@ void Sbar_IntermissionOverlay (void)
 	Draw_TransPic (xofs + (int)(pos * scale), (int)(64 * scale), sb_nums[0][num%10], true); pos += 20;
 	if (precision > 0)
 	{
+		Q_snprintfz(fracstring, sizeof(fracstring), "%.5f", cl.completed_time - (int)cl.completed_time);
+
 		pos += 6;
 		Draw_TransPic (xofs + (int)(pos  * scale), (int)(64 * scale), sb_colon, true); pos += 12;
-		remainder = fmodf(cl.completed_time, 1);
 		for (i = 0; i < precision; pos += 24, i++)
-		{
-			remainder *= 10.0f;
-			Draw_TransPic (xofs + (int)(pos * scale), (int)(64 * scale), sb_nums[0][(int)remainder], true);
-			remainder = fmodf(remainder, 1);
-		}
+			Draw_TransPic (xofs + (int)(pos * scale), (int)(64 * scale), sb_nums[0][fracstring[i + 2] - '0'], true);
 	}
 
 	// secrets

--- a/trunk/sbar.c
+++ b/trunk/sbar.c
@@ -69,7 +69,7 @@ int	sbar_xofs;
 cvar_t	scr_centersbar = {"scr_centersbar", "1"};
 cvar_t	scr_sbarscale_amount = { "scr_sbarscale_amount", "2" };
 cvar_t	scr_scorebarmode = { "scr_scorebarmode", "0" };
-cvar_t	scr_precisetime = { "scr_precisetime", "0" };
+cvar_t	scr_precisetime = { "scr_precisetime", "0", CVAR_ARCHIVE };
 
 /*
 ===============

--- a/trunk/sbar.c
+++ b/trunk/sbar.c
@@ -1462,7 +1462,8 @@ void Sbar_IntermissionOverlay (void)
 	int		dig, num, xofs, pos, i;
 	int precision;
 	float	scale;
-	char fracstring[8];
+	double frac;
+	char fracstring[9];
 
 	precision = (int)scr_timeprecision.value;
 	if (precision > 5)
@@ -1500,7 +1501,9 @@ void Sbar_IntermissionOverlay (void)
 	Draw_TransPic (xofs + (int)(pos * scale), (int)(64 * scale), sb_nums[0][num%10], true); pos += 20;
 	if (precision > 0)
 	{
-		Q_snprintfz(fracstring, sizeof(fracstring), "%.5f", cl.completed_time - (int)cl.completed_time);
+		frac = cl.completed_time - (int)cl.completed_time;
+		frac = bound(0.000005, frac, 0.999995);
+		Q_snprintfz(fracstring, sizeof(fracstring), "%.6f", frac);
 
 		pos += 6;
 		Draw_TransPic (xofs + (int)(pos  * scale), (int)(64 * scale), sb_colon, true); pos += 12;


### PR DESCRIPTION
Add a `scr_timeprecision` cvar to specify a number of decimal points displayed on the intermission screen time, eg 2:

![image](https://github.com/j0zzz/JoeQuake/assets/1709642/6da956a7-d03d-41fd-a4a3-a7f9717355e7)

Allows up to a maximum of 5 decimal places. When set to 5, the intermission time appears to match qdqstats exactly.  Without qdqstats the time may be off-by-one in the 5th decimal place relative to the time printed in the console.  I think this is because qdqstats truncates whereas non-qdqstats rounds when formatting?  In rare cases, without qdqstats, if `cl.intermission_time` is just below a whole number, 5.99999999 say, then the console will report 6.00000 whereas the intermission will report 0:05:99999.  Having said this, this bug exists in the code prior to this PR where the intermission screen would simply show 0:05.

Digit spacing and layout should match the old behavior exactly when `scr_timeprecision` is 0.  When `scr_timeprecision` is greater than 0 I've tried to make the formatting look nice and be right-aligned with the other rows.