### PR TITLE
stop sounds when loading a new map in a demo

### DIFF
--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -1358,6 +1358,8 @@ void CL_ParseServerMessage (void)
 			break;
 
 		case svc_serverinfo:
+			if (cls.demoplayback)
+				S_StopAllSounds (true);
 			CL_ParseServerInfo ();
 			vid.recalc_refdef = true;	// leave intermission full screen
 			break;


### PR DESCRIPTION
without this, ambient sounds (and maybe others?) can compound between maps.

Normally `S_StopAllSounds` is called in `CL_Disconnect`, but this doesn't happen with a multi-map demo.

repro steps:

1. Record a demo from start `record foo start`.  Walk through the teleporter and into episode 1. Stop at this point by the first door of E1M1 for a few seconds:
![image](https://github.com/j0zzz/JoeQuake/assets/1709642/61649662-a7f1-4e26-966e-52dc866bfb01)
2. Stop recording.
3. Play back the demo.  When you get to the point by the door you'll hear a fire crackling.
