### PR TITLE
Freefly mode

### DIFF
--- a/Windows/VisualStudio/JoeQuake.vcxproj
+++ b/Windows/VisualStudio/JoeQuake.vcxproj
@@ -597,6 +597,7 @@
     <ClCompile Include="..\..\trunk\world.c" />
     <ClCompile Include="..\..\trunk\zone.c" />
     <ClCompile Include="..\..\trunk\sys_win.c" />
+    <ClCompile Include="..\..\trunk\freefly.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\trunk\fakegl.h" />

--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -286,6 +286,10 @@ Server and Client framerates are independent. This setting is turned on by defau
 +set cl_independentphysics 0
 ```
 
+##### `freefly_speed`
+
+Set the speed the camera moves when in freefly mode.  `800` by default.
+
 #### Server
 
 ##### `sv_altnoclip`
@@ -1032,3 +1036,33 @@ an automatic name based on current map and time is used.
 
 Overrides the default `15` (NetQuake) protocol version with given value. Recognized values are `666` (FitzQuake) and `999` (RMQ).
 This command primarly aims to keep JoeQuake compatible with mods.
+
+##### `freefly`
+
+Toggle freefly mode.  This is a free flying third-person camera that can be used
+during demo playback.  See below for how to control the camera.
+
+##### `+freeflymove` / `-freeflymove`
+
+Enable movement of the camera in freefly mode.  When enabled, the usual inputs
+will manipulate the camera's position (`+moveleft`, `+moveright`, `+forward`,
+`+back`, mouse movements, etc).  You'll typically want to bind this to a key,
+which should be held down to move the camera.
+
+##### `freefly_copycam`
+
+Copy a ReMaic-style command to the clipboard, indicating the freefly camera's
+location, viewing direction, and current demo timestamp.  The output must be
+manipulated a little to make a valid ReMaic script --- the timestamp output as
+the third copied line must be used as a prefix for the next command, and
+likewise the copied `move` and `pan` command must be themselves prefixed with a
+timestamp from the previous command.  This is because ReMaic's move and pan
+commands indicate when the movement should *start* rather than when it should
+end, so timestamps need to be shifted on by one.
+
+This command currently does not work on the win32 build.
+
+##### `freefly_writecam [filename]`
+
+Like `freefly_copycam`, but append commands to the provided filename instead.
+This command is available on all builds.

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -49,6 +49,7 @@ int	demo_head_size[2];
 
 void CL_FinishTimeDemo (void);
 
+
 /*
 ==============================================================================
 DEMO CODE

--- a/trunk/cl_input.c
+++ b/trunk/cl_input.c
@@ -48,7 +48,7 @@ state bit 2 is edge triggered on the down to up transition
 ===============================================================================
 */
 
-kbutton_t	in_mlook, in_klook;
+kbutton_t	in_mlook, in_klook, in_freeflymove;
 kbutton_t	in_left, in_right, in_forward, in_back;
 kbutton_t	in_lookup, in_lookdown, in_moveleft, in_moveright;
 kbutton_t	in_strafe, in_speed, in_use, in_jump, in_attack;
@@ -128,6 +128,8 @@ void IN_MLookUp (void)
 	if (!mlook_active && lookspring.value)
 		V_StartPitchDrift ();
 }
+void IN_FreeFlyMoveDown (void) {KeyDown(&in_freeflymove);}
+void IN_FreeFlyMoveUp (void) {KeyUp(&in_freeflymove);}
 void IN_UpDown(void) {KeyDown(&in_up);}
 void IN_UpUp(void) {KeyUp(&in_up);}
 void IN_DownDown(void) {KeyDown(&in_down);}
@@ -494,6 +496,8 @@ void CL_InitInput (void)
 	Cmd_AddCommand ("-klook", IN_KLookUp);
 	Cmd_AddCommand ("+mlook", IN_MLookDown);
 	Cmd_AddCommand ("-mlook", IN_MLookUp);
+	Cmd_AddCommand ("+freeflymove", IN_FreeFlyMoveDown);
+	Cmd_AddCommand ("-freeflymove", IN_FreeFlyMoveUp);
 
 	Cmd_AddCommand ("bestweapon", IN_BestWeapon);
 

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -1411,6 +1411,7 @@ void CL_Init (void)
 	CL_InitTEnts ();
 	Ghost_Init ();
 	CL_InitDemo ();
+	FreeFly_Init ();
 
 // register our commands
 	Cvar_Register (&cl_name);

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -1165,7 +1165,7 @@ void CL_RelinkEntities (void)
 		}
 #endif
 
-		if (i == cl.viewentity && !cl_thirdperson.value)
+		if (i == cl.viewentity && !cl_thirdperson.value && !cl.freefly_enabled)
 			continue;
 
 		// nehahra support

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -247,6 +247,13 @@ typedef struct
 
 	unsigned	protocol; //johnfitz
 	unsigned	protocolflags;
+
+// freefly
+	qboolean	freefly_enabled;
+	qboolean	freefly_reset;
+	double		freefly_last_time;
+	vec3_t		freefly_origin;
+	vec3_t		freefly_angles;
 } client_state_t;
 
 extern	client_state_t	cl;
@@ -479,6 +486,12 @@ dzip_status_t DZip_CheckCompletion (dzip_context_t *ctx);
 dzip_status_t DZip_Open(dzip_context_t *ctx, const char *name, FILE **demo_file_p);
 void DZip_Cleanup(dzip_context_t *ctx);
 
+
+// cl_freefly.c
+void FreeFly_Init (void);
+void FreeFly_UpdateOrigin (void);
+void FreeFly_MouseMove (double x, double y);
+void FreeFly_SetRefdef (void);
 
 #ifdef GLQUAKE
 dlighttype_t SetDlightColor (float f, dlighttype_t def, qboolean random);

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -492,6 +492,7 @@ void FreeFly_Init (void);
 void FreeFly_UpdateOrigin (void);
 void FreeFly_MouseMove (double x, double y);
 void FreeFly_SetRefdef (void);
+qboolean FreeFly_Moving (void);
 
 #ifdef GLQUAKE
 dlighttype_t SetDlightColor (float f, dlighttype_t def, qboolean random);

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -3,7 +3,7 @@
 
 cvar_t	freefly_speed = {"freefly_speed", "800"};
 
-extern kbutton_t	in_freeflymove, in_forward, in_back, in_moveleft, in_moveright;
+extern kbutton_t	in_freeflymove, in_forward, in_back, in_moveleft, in_moveright, in_up, in_down, in_jump;
 
 static void FreeFly_Toggle_f (void)
 {
@@ -133,7 +133,8 @@ void FreeFly_MouseMove (double x, double y)
 void FreeFly_UpdateOrigin (void)
 {
 	double time, frametime;
-	vec3_t	forward, right, up, vel;
+	vec3_t forward, right, up, vel;
+	vec3_t world_up = {0, 0, 1};
 
 	if (!FreeFly_Moving())
 		return;
@@ -149,6 +150,12 @@ void FreeFly_UpdateOrigin (void)
 	VectorMA(vel,
 			 CL_KeyState (&in_moveright) - CL_KeyState (&in_moveleft),
 			 right,
+			 vel);
+	VectorMA(vel,
+			 CL_KeyState (&in_up)
+			 + CL_KeyState (&in_jump)
+			 - CL_KeyState (&in_down),
+			 world_up,
 			 vel);
 	VectorNormalize(vel);
 	VectorScale(vel, freefly_speed.value, vel);

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -46,7 +46,7 @@ static char *FreeFly_GetRemaicCommand (void)
 			 "%.2f\n",
 			 cl.freefly_origin[0],
 			 cl.freefly_origin[1],
-			 cl.freefly_origin[2],
+			 cl.freefly_origin[2] - DEFAULT_VIEWHEIGHT,
 			 trace.endpos[0],
 			 trace.endpos[1],
 			 trace.endpos[2],

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -84,6 +84,8 @@ static void FreeFly_WriteCam_f (void)
 	fprintf(f, "%s", cmd);
 
 	fclose (f);
+
+	Con_Printf("Remaic commands written to %s:\n%s", path, cmd);
 }
 
 

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -138,12 +138,12 @@ void FreeFly_UpdateOrigin (void)
 	vec3_t forward, right, up, vel;
 	vec3_t world_up = {0, 0, 1};
 
-	if (!FreeFly_Moving())
-		return;
-
 	time = Sys_DoubleTime();
 	frametime = time - cl.freefly_last_time;
 	cl.freefly_last_time = time;
+
+	if (!FreeFly_Moving())
+		return;
 
 	AngleVectors (cl.freefly_angles, forward, right, up);
 	VectorScale(forward,
@@ -168,8 +168,8 @@ void FreeFly_UpdateOrigin (void)
 void FreeFly_Init (void)
 {
 	Cvar_Register(&freefly_speed);
-	Cmd_AddCommand("freefly", FreeFly_Toggle_f);
 
+	Cmd_AddCommand("freefly", FreeFly_Toggle_f);
 	Cmd_AddCommand("freefly_copycam", FreeFly_CopyCam_f);
 	Cmd_AddCommand("freefly_writecam", FreeFly_WriteCam_f);
 }

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -106,6 +106,9 @@ qboolean FreeFly_Moving (void)
 
 void FreeFly_SetRefdef (void)
 {
+    if (!cls.demoplayback)
+        cl.freefly_enabled = false;
+
 	if (cl.freefly_enabled)
 	{
 		if (cl.freefly_reset)

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -19,6 +19,34 @@ static void FreeFly_Toggle_f (void)
 }
 
 
+static void FreeFly_CopyCam_f (void)
+{
+	vec3_t	forward, right, up, end;
+	char cam_buf[1024];
+
+	AngleVectors (cl.freefly_angles, forward, right, up);
+	VectorMA(cl.freefly_origin, 2048, forward, end);
+	if (!cl.freefly_enabled)
+	{
+		Con_Printf("freefly not enabled\n");
+		return;
+	}
+	snprintf(cam_buf, sizeof(cam_buf),
+			 "%.2f move %.1f %.1f %.1f\n"
+			 "%.2f pan %.1f %.1f %.1f\n",
+			  cl.mtime[0],
+			  cl.freefly_origin[0],
+			  cl.freefly_origin[1],
+			  cl.freefly_origin[2],
+			  cl.mtime[0],
+			  end[0],
+			  end[1],
+			  end[2]);
+	if (Sys_SetClipboardData(cam_buf))
+		Con_Printf("Remaic commands copy to clipboard\n");
+}
+
+
 qboolean FreeFly_Moving (void)
 {
 	return cl.freefly_enabled && (in_freeflymove.state & 1);
@@ -83,4 +111,6 @@ void FreeFly_Init (void)
 {
 	Cvar_Register(&freefly_speed);
 	Cmd_AddCommand("freefly", FreeFly_Toggle_f);
+
+	Cmd_AddCommand("freefly_copycam", FreeFly_CopyCam_f);
 }

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -1,0 +1,86 @@
+#include "quakedef.h"
+
+
+cvar_t	freefly_speed = {"freefly_speed", "800"};
+
+extern kbutton_t	in_freeflymove, in_forward, in_back, in_moveleft, in_moveright;
+
+static void FreeFly_Toggle_f (void)
+{
+	entity_t *ent;
+
+	cl.freefly_enabled = !cl.freefly_enabled;
+
+	if (cl.freefly_enabled)
+	{
+		cl.freefly_reset = true;
+		cl.freefly_last_time = Sys_DoubleTime();
+	}
+}
+
+
+qboolean FreeFly_Moving (void)
+{
+	return cl.freefly_enabled && (in_freeflymove.state & 1);
+}
+
+
+void FreeFly_SetRefdef (void)
+{
+	if (cl.freefly_enabled)
+	{
+		if (cl.freefly_reset)
+		{
+			VectorCopy (r_refdef.vieworg, cl.freefly_origin);
+			VectorCopy (r_refdef.viewangles, cl.freefly_angles);
+			cl.freefly_reset = false;
+		} else {
+			VectorCopy (cl.freefly_origin, r_refdef.vieworg);
+			VectorCopy (cl.freefly_angles, r_refdef.viewangles);
+		}
+	}
+}
+
+
+void FreeFly_MouseMove (double x, double y)
+{
+	if (!FreeFly_Moving())
+		return;
+
+	cl.freefly_angles[YAW] -= m_yaw.value * x;
+	cl.freefly_angles[PITCH] += m_pitch.value * y;
+	cl.freefly_angles[PITCH] = bound(-90, cl.freefly_angles[PITCH], 90);
+}
+
+
+void FreeFly_UpdateOrigin (void)
+{
+	double time, frametime;
+	vec3_t	forward, right, up, vel;
+
+	if (!FreeFly_Moving())
+		return;
+
+	time = Sys_DoubleTime();
+	frametime = time - cl.freefly_last_time;
+	cl.freefly_last_time = time;
+
+	AngleVectors (cl.freefly_angles, forward, right, up);
+	VectorScale(forward,
+				CL_KeyState (&in_forward) - CL_KeyState (&in_back),
+				vel);
+	VectorMA(vel,
+			 CL_KeyState (&in_moveright) - CL_KeyState (&in_moveleft),
+			 right,
+			 vel);
+	VectorNormalize(vel);
+	VectorScale(vel, freefly_speed.value, vel);
+	VectorMA(cl.freefly_origin, frametime, vel, cl.freefly_origin);
+}
+
+
+void FreeFly_Init (void)
+{
+	Cvar_Register(&freefly_speed);
+	Cmd_AddCommand("freefly", FreeFly_Toggle_f);
+}

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -7,8 +7,6 @@ extern kbutton_t	in_freeflymove, in_forward, in_back, in_moveleft, in_moveright;
 
 static void FreeFly_Toggle_f (void)
 {
-	entity_t *ent;
-
 	cl.freefly_enabled = !cl.freefly_enabled;
 
 	if (cl.freefly_enabled)

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -19,11 +19,16 @@ static void FreeFly_Toggle_f (void)
 
 static void FreeFly_CopyCam_f (void)
 {
+	trace_t	trace;
 	vec3_t	forward, right, up, end;
 	char cam_buf[1024];
 
 	AngleVectors (cl.freefly_angles, forward, right, up);
 	VectorMA(cl.freefly_origin, 2048, forward, end);
+
+	memset (&trace, 0, sizeof(trace));
+	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0, 1, cl.freefly_origin, end, &trace);
+
 	if (!cl.freefly_enabled)
 	{
 		Con_Printf("freefly not enabled\n");
@@ -37,11 +42,11 @@ static void FreeFly_CopyCam_f (void)
 			  cl.freefly_origin[1],
 			  cl.freefly_origin[2],
 			  cl.mtime[0],
-			  end[0],
-			  end[1],
-			  end[2]);
+			  trace.endpos[0],
+			  trace.endpos[1],
+			  trace.endpos[2]);
 	if (Sys_SetClipboardData(cam_buf))
-		Con_Printf("Remaic commands copy to clipboard\n");
+		Con_Printf("Remaic commands copy to clipboard:\n%s", cam_buf);
 }
 
 

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -115,6 +115,7 @@ void FreeFly_SetRefdef (void)
 		{
 			VectorCopy (r_refdef.vieworg, cl.freefly_origin);
 			VectorCopy (r_refdef.viewangles, cl.freefly_angles);
+			cl.freefly_angles[ROLL] = 0.;
 			cl.freefly_reset = false;
 		} else {
 			VectorCopy (cl.freefly_origin, r_refdef.vieworg);

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -3082,7 +3082,7 @@ void R_DrawViewModel (void)
 {
 	currententity = &cl.viewent;
 
-	if (!r_drawviewmodel.value || cl_thirdperson.value || !r_drawentities.value || 
+	if (!r_drawviewmodel.value || cl.freefly_enabled || cl_thirdperson.value || !r_drawentities.value || 
 	    (cl.stats[STAT_HEALTH] <= 0) || !currententity->model)
 		return;
 

--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -970,7 +970,7 @@ static void SCR_DrawCursor(void)
 	cursor_y = scr_pointer_state.y;
 
 	// Disable the cursor in all but following client parts
-	if (!CL_DemoUIOpen() && key_dest != key_menu)
+	if (FreeFly_Moving() || (!CL_DemoUIOpen() && key_dest != key_menu))
 		return;
 
 	if (scr_pointer_state.x != scr_pointer_state.x_old || scr_pointer_state.y != scr_pointer_state.y_old)

--- a/trunk/host.c
+++ b/trunk/host.c
@@ -806,6 +806,8 @@ void _Host_Frame (double time)
 		}
 	}
 
+	FreeFly_UpdateOrigin();
+
 	if (host_speeds.value)
 		time1 = Sys_DoubleTime ();
 

--- a/trunk/in_sdl.c
+++ b/trunk/in_sdl.c
@@ -289,7 +289,7 @@ static void IN_MouseMove (usercmd_t *cmd)
 	}
 	else
 	{
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !cl.freefly_enabled))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_Moving()))
 		{
 			mouse_x *= cursor_sensitivity.value;
 			mouse_y *= cursor_sensitivity.value;

--- a/trunk/in_sdl.c
+++ b/trunk/in_sdl.c
@@ -276,7 +276,7 @@ static void IN_MouseMove (usercmd_t *cmd)
 		float mousespeed = sqrt(mx * mx + my * my);
 		float m_accel_factor = m_accel.value * 0.1;
 
-		if (key_dest == key_menu || key_dest == key_console || CL_DemoUIOpen())
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_Moving()))
 		{
 			mouse_x *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
 			mouse_y *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
@@ -310,7 +310,6 @@ static void IN_MouseMove (usercmd_t *cmd)
 	//
 	if (key_dest != key_menu && key_dest != key_console && !CL_DemoUIOpen())
 	{
-
 		// add mouse X/Y movement to cmd
 		if ((in_strafe.state & 1) || (lookstrafe.value && mlook_active))
 			cmd->sidemove += m_side.value * mouse_x;

--- a/trunk/in_sdl.c
+++ b/trunk/in_sdl.c
@@ -289,7 +289,7 @@ static void IN_MouseMove (usercmd_t *cmd)
 	}
 	else
 	{
-		if (key_dest == key_menu || key_dest == key_console || CL_DemoUIOpen())
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !cl.freefly_enabled))
 		{
 			mouse_x *= cursor_sensitivity.value;
 			mouse_y *= cursor_sensitivity.value;
@@ -301,12 +301,16 @@ static void IN_MouseMove (usercmd_t *cmd)
 		}
 	}
 
+	if (key_dest != key_menu && key_dest != key_console)
+		FreeFly_MouseMove(mouse_x, mouse_y);
+
 	//
 	// Do not move the player if we're in menu mode.
 	// And don't apply ingame sensitivity, since that will make movements jerky.
 	//
 	if (key_dest != key_menu && key_dest != key_console && !CL_DemoUIOpen())
 	{
+
 		// add mouse X/Y movement to cmd
 		if ((in_strafe.state & 1) || (lookstrafe.value && mlook_active))
 			cmd->sidemove += m_side.value * mouse_x;

--- a/trunk/in_win.c
+++ b/trunk/in_win.c
@@ -1111,7 +1111,7 @@ void IN_MouseMove (usercmd_t *cmd)
 		float mousespeed = sqrt(mx * mx + my * my);
 		float m_accel_factor = m_accel.value * 0.1;
 
-		if (key_dest == key_menu || key_dest == key_console || CL_DemoUIOpen())
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_Moving()))
 		{
 			mouse_x *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
 			mouse_y *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
@@ -1124,7 +1124,7 @@ void IN_MouseMove (usercmd_t *cmd)
 	}
 	else
 	{
-		if (key_dest == key_menu || key_dest == key_console || CL_DemoUIOpen())
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_Moving()))
 		{
 			mouse_x *= cursor_sensitivity.value;
 			mouse_y *= cursor_sensitivity.value;
@@ -1135,6 +1135,9 @@ void IN_MouseMove (usercmd_t *cmd)
 			mouse_y *= sensitivity.value;
 		}
 	}
+
+	if (key_dest != key_menu && key_dest != key_console)
+		FreeFly_MouseMove(mouse_x, mouse_y);
 
 	//
 	// Do not move the player if we're in menu mode. 

--- a/trunk/keys.c
+++ b/trunk/keys.c
@@ -936,7 +936,7 @@ static qboolean Mouse_EventDispatch(void)
 		break;
 	}
 
-	if (!mouse_handled && CL_DemoUIOpen())
+	if (!mouse_handled && CL_DemoUIOpen() && !FreeFly_Moving())
 		mouse_handled = DemoUI_MouseEvent(&scr_pointer_state);
 
 	return mouse_handled;

--- a/trunk/r_main.c
+++ b/trunk/r_main.c
@@ -603,7 +603,7 @@ void R_DrawViewModel (void)
 
 	currententity = &cl.viewent;
 
-	if (!r_drawviewmodel.value || cl_thirdperson.value || !r_drawentities.value || 
+	if (!r_drawviewmodel.value || cl.freefly_enabled || cl_thirdperson.value || !r_drawentities.value || 
 	    (cl.items & IT_INVISIBILITY) || (cl.stats[STAT_HEALTH] <= 0) || !currententity->model)
 		return;
 

--- a/trunk/sys.h
+++ b/trunk/sys.h
@@ -54,3 +54,4 @@ void Sys_HighFPPrecision (void);
 void Sys_SetFPCW (void);
 
 char *Sys_GetClipboardData (void);
+qboolean Sys_SetClipboardData (const char *text);

--- a/trunk/sys_win.c
+++ b/trunk/sys_win.c
@@ -19,6 +19,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // sys_win.c -- Win32 system interface code
 
+#if defined(SDL2)
+#include <SDL.h>
+#endif
+
 #include "quakedef.h"
 #include "winquake.h"
 #include "resource.h"
@@ -502,6 +506,26 @@ char *Sys_GetClipboardData (void)
 
 	return clipboard;
 }
+
+#if !defined(SDL2)
+qboolean Sys_SetClipboardData (const char *text)
+{
+	// TODO: Implement this
+	Con_Printf("Copying to clipboard not supported on windows build\n");
+	return false;
+}
+#else
+// TODO: Implement for non-SDL2
+qboolean Sys_SetClipboardData (const char *text)
+{
+	qboolean success;
+	success = (SDL_SetClipboardText(text) == 0);
+	if (!success)
+		Con_Printf("Error setting clipboard: %s\n", SDL_GetError());
+	return success;
+}
+#endif
+
 
 /*
 ==============================================================================

--- a/trunk/view.c
+++ b/trunk/view.c
@@ -1148,6 +1148,8 @@ void V_CalcRefdef (void)
 	if (cl_thirdperson.value)
 		Chase_Update ();
 
+	FreeFly_SetRefdef ();
+
 // bound minpitch/maxpitch
 	if (cl_minpitch.value < -90)
 		Cvar_SetValue(&cl_minpitch, -90);

--- a/trunk/view.c
+++ b/trunk/view.c
@@ -1075,6 +1075,9 @@ void V_CalcIntermissionRefdef (void)
 	v_idlescale.value = 1;
 	V_AddIdle ();
 	v_idlescale.value = old;
+
+	FreeFly_SetRefdef ();
+
 }
 
 float	cl_punchangle, cl_ideal_punchangle;


### PR DESCRIPTION
I added a free flying camera during demo playback.  This should be handy for analyzing demos (particularly with the demo UI).  It should also be a big help with creating ReMaic scripts for recams (Connor has been testing).  You can see it in use in this clip: https://www.youtube.com/watch?v=XnEci3iSmgU

## Docs

##### `freefly`

Toggle freefly mode.  This is a free flying third-person camera that can be used
during demo playback.  See below for how to control the camera.

##### `+freeflymove` / `-freeflymove`

Enable movement of the camera in freefly mode.  When enabled, the usual inputs
will manipulate the camera's position (`+moveleft`, `+moveright`, `+forward`,
`+back`, mouse movements, etc).  You'll typically want to bind this to a key,
which should be held down to move the camera.

##### `freefly_copycam`

Copy a ReMaic-style command to the clipboard, indicating the freefly camera's
location, viewing direction, and current demo timestamp.  The output must be
manipulated a little to make a valid ReMaic script --- the timestamp output as
the third copied line must be used as a prefix for the next command, and
likewise the copied `move` and `pan` command must be themselves prefixed with a
timestamp from the previous command.  This is because ReMaic's move and pan
commands indicate when the movement should *start* rather than when it should
end, so timestamps need to be shifted on by one.

This command currently does not work on the win32 build.

##### `freefly_writecam [filename]`

Like `freefly_copycam`, but append commands to the provided filename instead.
This command is available on all builds.