### PR TITLE
Use perfect fixed interval ticks/physics frames or, by default, integer multiples

### DIFF
--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -60,6 +60,7 @@ cvar_t	cl_gibfilter = {"cl_gibfilter", "0"};
 cvar_t	cl_maxfps = {"cl_maxfps", "72", CVAR_SERVER};
 cvar_t	cl_advancedcompletion = {"cl_advancedcompletion", "1"};
 cvar_t	cl_independentphysics = {"cl_independentphysics", "1", CVAR_INIT};
+cvar_t	cl_mergeticks = {"cl_mergeticks", "1"};
 cvar_t	cl_viewweapons = {"cl_viewweapons", "0"};
 cvar_t	cl_autodemo = { "cl_autodemo", "0" };
 cvar_t	cl_autodemo_name = { "cl_autodemo_name", "" };
@@ -1447,6 +1448,7 @@ void CL_Init (void)
 	Cvar_Register (&cl_maxfps);
 	Cvar_Register (&cl_advancedcompletion);
 	Cvar_Register (&cl_independentphysics);
+	Cvar_Register (&cl_mergeticks);
 	Cvar_Register (&cl_viewweapons);
 	Cvar_Register(&cl_autodemo);
 	Cvar_Register(&cl_autodemo_name);

--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -182,6 +182,10 @@ static void Ghost_UpdateMarathon (void)
     ghost_marathon_level_t *gml;
     ghost_marathon_info_t *gmi = &ghost_marathon_info;
 
+    if (ghost_demo_path[0] == '\0') {
+        return;
+    }
+
     gmi->ghost_start = 0;
     gmi->total_split = 0.0f;
     for (i = 0; i < gmi->num_levels && i < MAX_MARATHON_LEVELS; i++) {

--- a/trunk/gl_rpart.c
+++ b/trunk/gl_rpart.c
@@ -1947,12 +1947,14 @@ void QMB_LightningSplash (vec3_t org)
 void QMB_LightningBeam (vec3_t start, vec3_t end)
 {
 	vec3_t	neworg;
+	double  frametime;
 
 	// only update LG beam on tick
 	if (!physframecount)
 		return;
 
-	AddParticle (p_lightningbeam, start, 1, 80, physframetime * 2, NULL, end);
+	frametime = max(physframetime, host_frametime);
+	AddParticle (p_lightningbeam, start, 1, 80, frametime * 2, NULL, end);
 
 	if (TraceLineN(start, end, neworg, NULL))
 	{

--- a/trunk/host.c
+++ b/trunk/host.c
@@ -558,7 +558,8 @@ static double MinPhysFrameTime(void)
 {
 	double physfps = !cl_maxfps.value ? 72 : bound(10, cl_maxfps.value, 72);
 
-	return 1.0 / physfps;
+	// simulate limited clock resolution and overshoot like vanilla cl_maxfps
+	return ((int)(1e7 / physfps) + 1) * 1e-7;
 }
 
 /*


### PR DESCRIPTION
This adds support for fixed tick deltatime and multiple ticks per render frame. `cl_mergeticks` (default `1`) disables simulating multiple ticks per frame and instead ticks only once, consuming the highest possible integer multiple of the tick interval from the accumulated time, avoiding slowdown on PCs that can't handle 72 tick at the expense of determinism by default.

Input is sampled once per frame, but mwheel inputs, `wait`, mouse strafe, `m_filter`, and `CL_KeyState` should all be properly accounted for when running multiple ticks/usercmds per frame.