### PR TITLE
fix crash on level change following #144

### DIFF
--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -454,7 +454,9 @@ void Ghost_Load (void)
         ghost_marathon_info.num_levels = 0;
     }
 
-    Ghost_UpdateMarathon();
+    if (ghost_demo_path[0]) {
+        Ghost_UpdateMarathon();
+    }
     Ghost_SetForLevel();
     Ghost_PrintLevelLoadInfo();
 }


### PR DESCRIPTION
PR #144 adds a call to Ghost_UpdateMarathon() when changing level. This function dereferences ghost_info, which is NULL if no ghost is loaded, causing a crash.  The fix is to not call the function when no ghost is loaded.