### PR TITLE
Fix `cl.onground` for packets without clientdata

### DIFF
--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -1300,7 +1300,11 @@ void CL_ParseServerMessage (void)
 	else if (cl_shownet.value == 2)
 		Con_Printf ("------------------\n");
 
-	cl.onground = false;	// unless the server says otherwise
+	// Sphere -- vanilla Quake reset cl.onground to false as a default here,
+	// which may not be overwritten with the correct value when the server sends
+	// packets without a clientdata message. Since a clientdata message always
+	// sets cl.onground, we do not need a default and can instead keep it at
+	// whatever it was on the last received one.
 
 // parse the message
 	MSG_BeginReading ();


### PR DESCRIPTION
Setting `cl.onground` to `false` as a default on parsing server messages is problematic, as it is not overwritten with the correct info whenever the server sends packets without a clientdata message. If the player is actually on the ground, the flag will quickly flicker on and off between received server packets, depending on if a packet contains a clientdata message or not. That can then break the view step smoothing when on elevators or slopes, since it relies on the `cl.onground` flag: https://github.com/j0zzz/JoeQuake/blob/df11cbadcf4ac031e5b8873a78ab7f3c58d344ed/trunk/cl_main.c#L1233 This was for example very apparent on the start elevator of Arcane Dimensions.

Since a clientdata message always sets `cl.onground` here,
https://github.com/j0zzz/JoeQuake/blob/df11cbadcf4ac031e5b8873a78ab7f3c58d344ed/trunk/cl_parse.c#L879 we do not need a default and can instead keep it at whatever it was on the last received one if we do not have a new one.

See also the corresponding fix in Quakespasm https://github.com/sezero/quakespasm/commit/d7c8111ea05605d028f79babd808c99c8dca5bda that also references the dicussion in https://www.celephais.net/board/view_thread.php?id=61381&start=660&end=665.