### PR TITLE
Fix wrong size for already loaded images

### DIFF
--- a/trunk/gl_draw.c
+++ b/trunk/gl_draw.c
@@ -2097,6 +2097,8 @@ static	gltexture_t	*current_texture = NULL;
 #define CHECK_TEXTURE_ALREADY_LOADED\
 	if (CheckTextureLoaded(mode))	\
 	{								\
+		image_width = current_texture->width; \
+		image_height = current_texture->height; \
 		current_texture = NULL;		\
 		fclose (f);					\
 		return NULL;				\


### PR DESCRIPTION
`GL_LoadImagePixels` has a check for if the image is already loaded and reuses the data if it is. However, the globals `image_width` and `image_height` are not set, so whatever value they last had is used for binding the already loaded image, which may not be correct.

This happens for example in Arcane Dimensions. Go on map start, then change to map ad_tears and then load map start again. Now the skybox texture will be broken with visible seams as it is reloaded with the wrong image size.

To fix that, we set `image_width` and `image_height` to the size of the found already loaded `current_texture`.