### PR TITLE
Workaround for skyfog value not being reset

### DIFF
--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -101,6 +101,13 @@ Applies fog on the sky, valid values are from `0.0` to `1.0`. Used implicitly by
 It is only used if fog is also applied by using the `fog` command.
 Default value is `0.5`.
 
+##### `r_skyfog_default`
+
+Same as `r_skyfog`, but is used to initialize the fog amount at the start of a map only.
+Once `r_skyfog` is changed, it overrides this value.
+This is a workaround for when mods do not reset `r_skyfog` at the start of a map, causing whatever value from the end of the previous map to be used instead, which may not be intended.
+Default value is `0.5`.
+
 ##### `r_noshadow_list`
 
 Ignores drawing shadow for mdl files added to this list.

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -112,6 +112,7 @@ qboolean OnChange_r_skybox (cvar_t *var, char *string);
 cvar_t	r_skybox = {"r_skybox", "", 0, OnChange_r_skybox };
 qboolean OnChange_r_skyfog(cvar_t *var, char *string);
 cvar_t	r_skyfog = { "r_skyfog", "0.5", 0, OnChange_r_skyfog };
+cvar_t	r_skyfog_default = { "r_skyfog_default", "0.5" };
 cvar_t	r_scale = { "r_scale", "1" };
 
 cvar_t	gl_clear = {"gl_clear", "1"};
@@ -3506,6 +3507,7 @@ void R_Init (void)
 	Cvar_Register (&r_skybox);
 	Cvar_Register (&r_farclip);
 	Cvar_Register (&r_skyfog);
+	Cvar_Register (&r_skyfog_default);
 	Cvar_Register (&r_scale);
 	Cvar_Register(&r_waterquality);
 	Cvar_Register(&r_oldwater);

--- a/trunk/gl_warp.c
+++ b/trunk/gl_warp.c
@@ -40,6 +40,7 @@ cvar_t r_waterwarp = { "r_waterwarp", "0" };
 
 extern	cvar_t	gl_subdivide_size;
 extern	cvar_t	r_skyfog;
+extern	cvar_t	r_skyfog_default;
 
 extern	byte *StringToRGB (char *s);
 
@@ -1141,7 +1142,7 @@ void Sky_NewMap(void)
 
 	// initially no sky
 	Cvar_Set(&r_skybox, "");
-	skyfog = r_skyfog.value;
+	skyfog = r_skyfog_default.value;
 
 	// read worldspawn (this is so ugly, and shouldn't it be done on the server?)
 	data = cl.worldmodel->entities;


### PR DESCRIPTION
When mods do not reset `r_skyfog` to a default value on the start of a map, instead it will use the value from the end of the previous map.

This happens for example with ad_tears: The final fight area of ad_tears sets `r_skyfog` to a very low value, so there is basically no fog. After ending the map, you return back to the start map. But it does not reset the fog to its default value of `0.5`, so you get a wrong looking sky without any fog. This should probably be fixed in Arcane Dimensions itself?

This is an engine-side workaround for this. Instead of using `r_skyfog` which may be modified by mods, we use a new seperate variable `r_skyfog_default` to initialize the fog when loading a map. Once a mod does any changes to `r_skyfog`, that value will be used instead.