### PR TITLE
Fix speedometer in multiplayer

### DIFF
--- a/trunk/view.c
+++ b/trunk/view.c
@@ -1257,7 +1257,7 @@ void SCR_DrawSpeed (void)
 		maxspeed = 0;
 	}
 
-	if (cls.demoplayback || coop.value)
+	if (cls.demoplayback || !sv.active || svs.maxclients != 1)
 		VectorCopy(cl.velocity, vel);
 	else
 		VectorCopy (sv_velocity, vel);


### PR DESCRIPTION
The existing check for when we have to fallback to the inaccurate client speed is flawed.

Checking the `coop` cvar makes sure that the host falls back to showing client-side speed when they are hosting a coop server. But in other multiplayer scenarios like deathmatch, their speedometer will be broken. Also when just playing singleplayer but coincidentally having set the `coop` cvar to 1, they will get the less accurate speed display for no good reason.

Non-host clients of multiplayer games on the other hand will have no speed display at all, unless their unused coop cvar happens to be 1 by chance.

We really only need to choose the fallback method if either we are not hosting and just connected to a server (`!sv.active`) or if we are hosting a game with multiple players (`svs.maxclients != 1`).