### PR TITLE
Freefly improvements

### DIFF
--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -1053,14 +1053,21 @@ This command primarly aims to keep JoeQuake compatible with mods.
 ##### `freefly`
 
 Toggle freefly mode.  This is a free flying third-person camera that can be used
-during demo playback.  See below for how to control the camera.
+during demo playback.  When enabled, the usual inputs will manipulate the
+camera's position and angle (`+moveleft`, `+moveright`, `+forward`, `+back`,
+mouse movements, etc).
+
+If the demo UI is enabled (`cl_demoui 1`) then click and drag with mouse2 to
+change the camera angle, or bind `+freeflymove` (see below).  If the demo UI is
+disabled (`cl_demoui 0`) then mouse movements will effect the camera angle
+without need for extra key or button presses.
 
 ##### `+freeflymove` / `-freeflymove`
 
-Enable movement of the camera in freefly mode.  When enabled, the usual inputs
-will manipulate the camera's position (`+moveleft`, `+moveright`, `+forward`,
-`+back`, mouse movements, etc).  You'll typically want to bind this to a key,
-which should be held down to move the camera.
+When using freefly mode with the demo UI, this command makes mouse movements
+adjust the camera angle.  Use this as an alternative to mouse2.  You'll
+typically want to bind this to a key, which should be held down to adjust the
+camera angle.
 
 ##### `freefly_copycam`
 

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -444,8 +444,8 @@ Get_TooltipText (void)
 		case HOVER_SKIP_PREV:
 			tooltip_text = "skip to previous level in marathon"; break;
 		case HOVER_SPEED_NEXT:
-			tooltip_text = "cycle forwards through playback speeds"; break;
 		case HOVER_SPEED:
+			tooltip_text = "cycle forwards through playback speeds"; break;
 		case HOVER_SPEED_PREV:
 			tooltip_text = "cycle backwards through playback speeds"; break;
 		case HOVER_FREEFLY:

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -591,6 +591,13 @@ void DemoUI_Draw(void)
 
 	// Tooltip
 	tooltip_text = Get_TooltipText();
-	Draw_String(vid.width - layout.char_size * strlen(tooltip_text),
-				layout.top - 3 * (layout.char_size >> 1), tooltip_text, true);
+	if (tooltip_text[0] != '\0')
+	{
+		Draw_AlphaFill(vid.width - layout.char_size * strlen(tooltip_text) - (layout.char_size >> 2),
+						layout.top - 3 * (layout.char_size >> 1),
+						((layout.char_size >> 2) + layout.char_size * strlen(tooltip_text)) / sbar_scale,
+						3 * (layout.char_size >> 1) / sbar_scale, 0, 0.7);
+		Draw_String(vid.width - layout.char_size * strlen(tooltip_text),
+					layout.top - 5 * (layout.char_size >> 2), tooltip_text, true);
+	}
 }

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -411,6 +411,34 @@ TimeToSeekbarPos (double time, dseek_map_info_t *dsmi, layout_t *layout)
 }
 
 
+static char *
+Get_TooltipText (void)
+{
+	char *tooltip_text;
+	switch (hover)
+	{
+		case HOVER_PLAY_PAUSE:
+			tooltip_text = "toggle play/pause"; break;
+		case HOVER_SEEK:
+			tooltip_text = "seek through current level"; break;
+		case HOVER_SKIP_NEXT:
+			tooltip_text = "skip to next level in marathon"; break;
+		case HOVER_SKIP:
+			tooltip_text = "toggle marathon level menu"; break;
+		case HOVER_SKIP_PREV:
+			tooltip_text = "skip to previous level in marathon"; break;
+		case HOVER_SPEED_NEXT:
+			tooltip_text = "cycle forwards through playback speeds"; break;
+		case HOVER_SPEED:
+		case HOVER_SPEED_PREV:
+			tooltip_text = "cycle backwards through playback speeds"; break;
+		default:
+			tooltip_text = "";
+	}
+	return tooltip_text;
+}
+
+
 void DemoUI_Draw(void)
 {
 	float sbar_scale = Sbar_GetScaleAmount();
@@ -422,6 +450,7 @@ void DemoUI_Draw(void)
 	dseek_map_info_t *dsmi;
 	int map_num;
 	layout_t layout;
+	char *tooltip_text;
 
 	dsmi = CL_DemoGetCurrentMapInfo (&map_num);
 	if (dsmi == NULL)
@@ -530,4 +559,9 @@ void DemoUI_Draw(void)
 							demo_seek_info.maps[i].name, true);
 		}
 	}
+
+	// Tooltip
+	tooltip_text = Get_TooltipText();
+	Draw_String(vid.width - layout.char_size * strlen(tooltip_text),
+				layout.top - 3 * (layout.char_size >> 1), tooltip_text, true);
 }

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -36,7 +36,7 @@ typedef enum
 
 
 qboolean demoui_dragging_seek;
-qboolean demoui_freefly_move;
+qboolean demoui_freefly_mlook;
 static double last_event_time = -1.0f;
 static qboolean over_ui = false;
 static qboolean map_menu_open = false;
@@ -278,7 +278,7 @@ qboolean DemoUI_MouseEvent(const mouse_state_t* ms)
 	UpdateHover(&layout, ms);
 	over_ui = ms->y > layout.top || (map_menu_open && hover_map_idx != -1);
 
-	demoui_freefly_move = ms->buttons[2];
+	demoui_freefly_mlook = ms->buttons[2];
 	if (ms->button_down == 2 || ms->button_up == 2)
 	{
 		handled = true;

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -3,7 +3,7 @@
 #define SPEED_DRAW_CHARS	6
 #define MAP_NAME_DRAW_CHARS	12
 #define PAUSE_PLAY_CHARS	2
-#define FREEFLY_CHARS	2
+#define FREEFLY_CHARS	4
 
 
 typedef struct
@@ -449,7 +449,7 @@ Get_TooltipText (void)
 		case HOVER_SPEED_PREV:
 			tooltip_text = "cycle backwards through playback speeds"; break;
 		case HOVER_FREEFLY:
-			tooltip_text = "toggle between freefly and first person view"; break;
+			tooltip_text = "toggle between freefly (1) and first person view (0)"; break;
 		default:
 			tooltip_text = "";
 	}
@@ -580,14 +580,14 @@ void DemoUI_Draw(void)
 	}
 
 	// Freefly
-	if (cl.freefly_enabled)
-		freefly_label = "FF";
-	else
-		freefly_label = "1P";
 	if (hover == HOVER_FREEFLY)
-		Draw_String(layout.freefly_x, layout.freefly_y, freefly_label, true);
+		Draw_String(layout.freefly_x, layout.freefly_y, "FF:", true);
 	else
-		Draw_Alt_String(layout.freefly_x, layout.freefly_y, freefly_label, true);
+		Draw_Alt_String(layout.freefly_x, layout.freefly_y, "FF:", true);
+	if (cl.freefly_enabled)
+		Draw_String(layout.freefly_x + layout.char_size * 3, layout.freefly_y, "1", true);
+	else
+		Draw_String(layout.freefly_x + layout.char_size * 3, layout.freefly_y, "0", true);
 
 	// Tooltip
 	tooltip_text = Get_TooltipText();

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -263,9 +263,13 @@ qboolean DemoUI_MouseEvent(const mouse_state_t* ms)
 
 	UpdateHover(&layout, ms);
 	over_ui = ms->y > layout.top || (map_menu_open && hover_map_idx != -1);
-	demoui_freefly_move = (ms->button_down == 2);
 
-	if (ms->button_down == 1)
+	demoui_freefly_move = ms->buttons[2];
+	if (ms->button_down == 2 || ms->button_up == 2)
+	{
+		handled = true;
+	}
+	else if (ms->button_down == 1)
 	{
 		handled = true;
 		switch (hover)
@@ -368,6 +372,7 @@ qboolean DemoUI_MouseEvent(const mouse_state_t* ms)
 			map_menu_open = false;
 		else
 			Cmd_ExecuteString("pause", src_command);
+		handled = true;
 	}
 
 	return handled;

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -33,6 +33,7 @@ typedef enum
 
 
 qboolean demoui_dragging_seek;
+qboolean demoui_freefly_move;
 static double last_event_time = -1.0f;
 static qboolean over_ui = false;
 static qboolean map_menu_open = false;
@@ -262,6 +263,7 @@ qboolean DemoUI_MouseEvent(const mouse_state_t* ms)
 
 	UpdateHover(&layout, ms);
 	over_ui = ms->y > layout.top || (map_menu_open && hover_map_idx != -1);
+	demoui_freefly_move = (ms->button_down == 2);
 
 	if (ms->button_down == 1)
 	{

--- a/trunk/cl_input.c
+++ b/trunk/cl_input.c
@@ -48,7 +48,7 @@ state bit 2 is edge triggered on the down to up transition
 ===============================================================================
 */
 
-kbutton_t	in_mlook, in_klook, in_freeflymove;
+kbutton_t	in_mlook, in_klook, in_freeflymlook;
 kbutton_t	in_left, in_right, in_forward, in_back;
 kbutton_t	in_lookup, in_lookdown, in_moveleft, in_moveright;
 kbutton_t	in_strafe, in_speed, in_use, in_jump, in_attack;
@@ -128,8 +128,8 @@ void IN_MLookUp (void)
 	if (!mlook_active && lookspring.value)
 		V_StartPitchDrift ();
 }
-void IN_FreeFlyMoveDown (void) {KeyDown(&in_freeflymove);}
-void IN_FreeFlyMoveUp (void) {KeyUp(&in_freeflymove);}
+void IN_FreeFlyMLookDown (void) {KeyDown(&in_freeflymlook);}
+void IN_FreeFlyMLookUp (void) {KeyUp(&in_freeflymlook);}
 void IN_UpDown(void) {KeyDown(&in_up);}
 void IN_UpUp(void) {KeyUp(&in_up);}
 void IN_DownDown(void) {KeyDown(&in_down);}
@@ -496,8 +496,8 @@ void CL_InitInput (void)
 	Cmd_AddCommand ("-klook", IN_KLookUp);
 	Cmd_AddCommand ("+mlook", IN_MLookDown);
 	Cmd_AddCommand ("-mlook", IN_MLookUp);
-	Cmd_AddCommand ("+freeflymove", IN_FreeFlyMoveDown);
-	Cmd_AddCommand ("-freeflymove", IN_FreeFlyMoveUp);
+	Cmd_AddCommand ("+freeflymlook", IN_FreeFlyMLookDown);
+	Cmd_AddCommand ("-freeflymlook", IN_FreeFlyMLookUp);
 
 	Cmd_AddCommand ("bestweapon", IN_BestWeapon);
 

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -420,7 +420,7 @@ qboolean CL_DemoUIOpen(void);
 // cl_demoui.c
 typedef struct mouse_state_s mouse_state_t;
 extern qboolean demoui_dragging_seek;
-extern qboolean demoui_freefly_move;
+extern qboolean demoui_freefly_mlook;
 qboolean DemoUI_MouseEvent(const mouse_state_t* ms);
 void DemoUI_Draw(void);
 qboolean DemoUI_Visible(void);
@@ -493,7 +493,7 @@ void FreeFly_Init (void);
 void FreeFly_UpdateOrigin (void);
 void FreeFly_MouseMove (double x, double y);
 void FreeFly_SetRefdef (void);
-qboolean FreeFly_Moving (void);
+qboolean FreeFly_MLook (void);
 
 #ifdef GLQUAKE
 dlighttype_t SetDlightColor (float f, dlighttype_t def, qboolean random);

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -420,6 +420,7 @@ qboolean CL_DemoUIOpen(void);
 // cl_demoui.c
 typedef struct mouse_state_s mouse_state_t;
 extern qboolean demoui_dragging_seek;
+extern qboolean demoui_freefly_move;
 qboolean DemoUI_MouseEvent(const mouse_state_t* ms);
 void DemoUI_Draw(void);
 qboolean DemoUI_Visible(void);

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -100,7 +100,8 @@ static void FreeFly_CopyCam_f (void)
 
 qboolean FreeFly_Moving (void)
 {
-	return cl.freefly_enabled && (in_freeflymove.state & 1);
+	return cl.freefly_enabled
+		&& (cl_demoui.value == 0 || (in_freeflymove.state & 1) || demoui_freefly_move);
 }
 
 

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -11,8 +11,14 @@ static void FreeFly_Toggle_f (void)
 
 	if (cl.freefly_enabled)
 	{
+		Con_Printf("Freefly enabled.");
+		if (cl_demoui.value != 0)
+			Con_Printf(" Hold mouse2 or bind +freeflymove to change view.");
+		Con_Printf("\n");
 		cl.freefly_reset = true;
 		cl.freefly_last_time = Sys_DoubleTime();
+	} else {
+		Con_Printf("Freefly disabled.\n");
 	}
 }
 

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -147,7 +147,7 @@ void FreeFly_UpdateOrigin (void)
 	frametime = time - cl.freefly_last_time;
 	cl.freefly_last_time = time;
 
-	if (!FreeFly_Moving())
+	if (!cl.freefly_enabled)
 		return;
 
 	AngleVectors (cl.freefly_angles, forward, right, up);

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -3,7 +3,7 @@
 
 cvar_t	freefly_speed = {"freefly_speed", "800"};
 
-extern kbutton_t	in_freeflymove, in_forward, in_back, in_moveleft, in_moveright, in_up, in_down, in_jump;
+extern kbutton_t	in_freeflymlook, in_forward, in_back, in_moveleft, in_moveright, in_up, in_down, in_jump;
 
 static void FreeFly_Toggle_f (void)
 {
@@ -20,7 +20,7 @@ static void FreeFly_Toggle_f (void)
 	{
 		Con_Printf("Freefly enabled.");
 		if (cl_demoui.value != 0)
-			Con_Printf(" Hold mouse2 or bind +freeflymove to change view.");
+			Con_Printf(" Hold mouse2 or bind +freeflymlook to change view.");
 		Con_Printf("\n");
 		cl.freefly_reset = true;
 		cl.freefly_last_time = Sys_DoubleTime();
@@ -111,10 +111,10 @@ static void FreeFly_CopyCam_f (void)
 }
 
 
-qboolean FreeFly_Moving (void)
+qboolean FreeFly_MLook (void)
 {
 	return cl.freefly_enabled
-		&& (cl_demoui.value == 0 || (in_freeflymove.state & 1) || demoui_freefly_move);
+		&& (cl_demoui.value == 0 || (in_freeflymlook.state & 1) || demoui_freefly_mlook);
 }
 
 
@@ -141,7 +141,7 @@ void FreeFly_SetRefdef (void)
 
 void FreeFly_MouseMove (double x, double y)
 {
-	if (!FreeFly_Moving())
+	if (!FreeFly_MLook())
 		return;
 
 	cl.freefly_angles[YAW] -= m_yaw.value * x;

--- a/trunk/freefly.c
+++ b/trunk/freefly.c
@@ -7,6 +7,13 @@ extern kbutton_t	in_freeflymove, in_forward, in_back, in_moveleft, in_moveright,
 
 static void FreeFly_Toggle_f (void)
 {
+	if (!cls.demoplayback)
+	{
+		Con_Printf("Must be playing a demo to enable freefly.\n");
+		cl.freefly_enabled = false;
+		return;
+	}
+
 	cl.freefly_enabled = !cl.freefly_enabled;
 
 	if (cl.freefly_enabled)

--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -970,7 +970,7 @@ static void SCR_DrawCursor(void)
 	cursor_y = scr_pointer_state.y;
 
 	// Disable the cursor in all but following client parts
-	if (FreeFly_Moving() || (!CL_DemoUIOpen() && key_dest != key_menu))
+	if ((CL_DemoUIOpen() && FreeFly_Moving()) || (!CL_DemoUIOpen() && key_dest != key_menu))
 		return;
 
 	if (scr_pointer_state.x != scr_pointer_state.x_old || scr_pointer_state.y != scr_pointer_state.y_old)

--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -970,7 +970,7 @@ static void SCR_DrawCursor(void)
 	cursor_y = scr_pointer_state.y;
 
 	// Disable the cursor in all but following client parts
-	if ((CL_DemoUIOpen() && FreeFly_Moving()) || (!CL_DemoUIOpen() && key_dest != key_menu))
+	if ((CL_DemoUIOpen() && FreeFly_MLook()) || (!CL_DemoUIOpen() && key_dest != key_menu))
 		return;
 
 	if (scr_pointer_state.x != scr_pointer_state.x_old || scr_pointer_state.y != scr_pointer_state.y_old)

--- a/trunk/in_sdl.c
+++ b/trunk/in_sdl.c
@@ -276,7 +276,7 @@ static void IN_MouseMove (usercmd_t *cmd)
 		float mousespeed = sqrt(mx * mx + my * my);
 		float m_accel_factor = m_accel.value * 0.1;
 
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_Moving()))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_MLook()))
 		{
 			mouse_x *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
 			mouse_y *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
@@ -289,7 +289,7 @@ static void IN_MouseMove (usercmd_t *cmd)
 	}
 	else
 	{
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_Moving()))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_MLook()))
 		{
 			mouse_x *= cursor_sensitivity.value;
 			mouse_y *= cursor_sensitivity.value;

--- a/trunk/in_win.c
+++ b/trunk/in_win.c
@@ -1111,7 +1111,7 @@ void IN_MouseMove (usercmd_t *cmd)
 		float mousespeed = sqrt(mx * mx + my * my);
 		float m_accel_factor = m_accel.value * 0.1;
 
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_Moving()))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_MLook()))
 		{
 			mouse_x *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
 			mouse_y *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
@@ -1124,7 +1124,7 @@ void IN_MouseMove (usercmd_t *cmd)
 	}
 	else
 	{
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_Moving()))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_MLook()))
 		{
 			mouse_x *= cursor_sensitivity.value;
 			mouse_y *= cursor_sensitivity.value;

--- a/trunk/keys.c
+++ b/trunk/keys.c
@@ -936,7 +936,7 @@ static qboolean Mouse_EventDispatch(void)
 		break;
 	}
 
-	if (!mouse_handled && CL_DemoUIOpen() && !FreeFly_Moving())
+	if (!mouse_handled && CL_DemoUIOpen())
 		mouse_handled = DemoUI_MouseEvent(&scr_pointer_state);
 
 	return mouse_handled;


### PR DESCRIPTION
A collection of improvements related to the freefly feature:
- Movement keys *always* move camera when freefly is enabled.  Previously +freeflymove had to be pressed.
- Mouse changes camera angle when freefly is enabled and demo ui is disabled (`cl_demoui 0`).  This makes sense, since the mouse isn't being used for anything else when the demo UI is off.
- When freefly is enabled, and the demo UI is enabled, mouse2 drag can be used to change the camera angle in addition to `+freeflymove`.  This means the user doesn't have to set up any special binds to use freefly.
- Add a freefly toggle button onto the demo UI.  Help text is printed to the console when freefly is enabled.
- A tooltip shows on the demo UI when hovering a clickable item.  I figured this might be helpful since it is not obvious what "ff:0" means.

Here's an image showing what the UI looks like now:
![image](https://github.com/user-attachments/assets/288da16a-b643-4ada-83e4-f09bcdf71e8e)