### PR TITLE
scr_autoid improvements

### DIFF
--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -816,6 +816,25 @@ void Ghost_Finish (char *map_name, double finish_time)
 }
 
 
+qboolean Ghost_AutoId (char *name, vec3_t origin)
+{
+    ghost_level_t *gcl = ghost_current_level;
+
+    if (ghost_current_level == NULL)
+        return false;
+    if (gcl->view_entity == 0)
+        return false;
+    if (gcl->view_entity - 1 >= GHOST_MAX_CLIENTS)
+        return false;
+    if (!Ghost_Update())
+        return false;
+
+    snprintf(name, MAX_SCOREBOARDNAME, "%s", gcl->client_names[gcl->view_entity - 1]);
+    VectorCopy(ghost_entity.origin, origin);
+
+    return true;
+}
+
 static void Ghost_PrintSummary (void)
 {
     extern char *skill_modes[];

--- a/trunk/ghost/ghost.h
+++ b/trunk/ghost/ghost.h
@@ -28,6 +28,7 @@ void Ghost_Draw (void);
 void Ghost_DrawGhostTime (qboolean intermission);
 void Ghost_Init (void);
 void Ghost_Finish (char *map_name, double finish_time);
+qboolean Ghost_AutoId (char *name, vec3_t origin);
 void Ghost_Shutdown (void);
 
 typedef struct {

--- a/trunk/ghost/ghost_private.h
+++ b/trunk/ghost/ghost_private.h
@@ -50,6 +50,7 @@ typedef struct {
 typedef struct {
     char map_name[GHOST_MAP_NAME_SIZE];
 
+    int view_entity;
     char client_names[GHOST_MAX_CLIENTS][MAX_SCOREBOARDNAME];
     byte client_colors[GHOST_MAX_CLIENTS];
     float finish_time;

--- a/trunk/ghost/ghostparse.c
+++ b/trunk/ghost/ghostparse.c
@@ -142,6 +142,8 @@ Ghost_SetView_cb (int entity_num, void *ctx)
     ghost_parse_ctx_t *pctx = ctx;
 
     pctx->view_entity = entity_num;
+    pctx->level->view_entity = entity_num;
+
     return DP_CBR_CONTINUE;
 }
 

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -3716,8 +3716,10 @@ void R_ScaleView(void)
 	glViewport(srcx, srcy, r_refdef.vrect.width, r_refdef.vrect.height);
 
 	glMatrixMode(GL_PROJECTION);
+	glPushMatrix();
 	glLoadIdentity();
 	glMatrixMode(GL_MODELVIEW);
+	glPushMatrix();
 	glLoadIdentity();
 
 	// correction factor if we lack NPOT textures, normally these are 1.0f
@@ -3734,6 +3736,11 @@ void R_ScaleView(void)
 	glTexCoord2f(0, tmax);
 	glVertex2f(-1, 1);
 	glEnd();
+
+	glMatrixMode(GL_PROJECTION);
+	glPopMatrix();
+	glMatrixMode(GL_MODELVIEW);
+	glPopMatrix();
 
 	// clear cached binding
 	currenttexture = -1;

--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -708,7 +708,9 @@ void SCR_SetupAutoID (void)
 	{
 		state = &cl_entities[1+i];
 
-		if (state == &cl_entities[cl.viewentity])
+		if (state == &cl_entities[cl.viewentity] &&
+				cl_thirdperson.value == 0 &&
+				!cl.freefly_enabled)
 		{
 			continue;
 		}

--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -681,7 +681,8 @@ typedef struct player_autoid_s
 	scoreboard_t	*player;
 } autoid_player_t;
 
-static	autoid_player_t	autoids[MAX_SCOREBOARDNAME];
+static	autoid_player_t	autoids[MAX_SCOREBOARD + 1];
+static	scoreboard_t autoid_ghost_scoreboard;
 static	int		autoid_count;
 
 #define ISDEAD(i) ((i) >= 41 && (i) <= 102)
@@ -690,6 +691,7 @@ void SCR_SetupAutoID (void)
 {
 	int		i, view[4];
 	float		model[16], project[16], winz, *origin;
+	vec3_t	ghost_origin;
 	entity_t	*state;
 	autoid_player_t	*id;
 
@@ -724,6 +726,19 @@ void SCR_SetupAutoID (void)
 		if (qglProject(origin[0], origin[1], origin[2] + 28, model, project, view, &id->x, &id->y, &winz))
 			autoid_count++;
 	}
+
+	id = &autoids[autoid_count];
+	id->player = &autoid_ghost_scoreboard;
+	if (Ghost_AutoId(autoid_ghost_scoreboard.name, ghost_origin))
+	{
+		if (!R_CullSphere(ghost_origin, 0)
+			&& qglProject(ghost_origin[0], ghost_origin[1], ghost_origin[2] + 28, model, project, view,
+						   &id->x, &id->y, &winz))
+		{
+			autoid_count++;
+		}
+	}
+
 }
 
 void SCR_DrawAutoID (void)

--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -690,8 +690,8 @@ static	int		autoid_count;
 void SCR_SetupAutoID (void)
 {
 	int		i, view[4];
-	float		model[16], project[16], winz, *origin;
-	vec3_t	ghost_origin;
+	float		model[16], project[16], winz;
+	vec3_t origin, ghost_origin;
 	entity_t	*state;
 	autoid_player_t	*id;
 
@@ -719,13 +719,14 @@ void SCR_SetupAutoID (void)
 		     state->modelindex == cl_modelindex[mi_h_player])
 			continue;
 
-		if (R_CullSphere(state->origin, 0))
+		VectorCopy(state->origin, origin);
+		origin[2] += 28;
+		if (R_CullSphere(origin, 0))
 			continue;
 
 		id = &autoids[autoid_count];
 		id->player = &cl.scores[i];
-		origin = state->origin;
-		if (qglProject(origin[0], origin[1], origin[2] + 28, model, project, view, &id->x, &id->y, &winz))
+		if (qglProject(origin[0], origin[1], origin[2], model, project, view, &id->x, &id->y, &winz))
 			autoid_count++;
 	}
 
@@ -733,8 +734,9 @@ void SCR_SetupAutoID (void)
 	id->player = &autoid_ghost_scoreboard;
 	if (Ghost_AutoId(autoid_ghost_scoreboard.name, ghost_origin))
 	{
+		ghost_origin[2] += 28;
 		if (!R_CullSphere(ghost_origin, 0)
-			&& qglProject(ghost_origin[0], ghost_origin[1], ghost_origin[2] + 28, model, project, view,
+			&& qglProject(ghost_origin[0], ghost_origin[1], ghost_origin[2], model, project, view,
 						   &id->x, &id->y, &winz))
 		{
 			autoid_count++;


### PR DESCRIPTION
Fixes https://github.com/j0zzz/JoeQuake/issues/164

A few scr_autoid related changes:
- 1a4b37ffad4bda62c2f6baf4e4a987145b8986b8 Show ghost player's name
- 46162de161f32eebc8829a1007d20f7bc919146d Show the view player's name when in 3rd person mode or freefly
- 62873f7e4d6f57bb43ca59b5f6c3d4c333b8a99f Fix an issue with frustum culling of names
- 18f36a2fcf30295715e306617991bbe40a8551e7 Fix [a bug](https://github.com/j0zzz/JoeQuake/issues/164) with r_scale