### PR TITLE
fix crash with playdemo dzip and pause

### DIFF
--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -207,11 +207,11 @@ int CL_GetMessage (void)
 	float	f;
 	qboolean backwards;
 
-	if (seek_time < 0 && (cl.paused & 2 || demoui_dragging_seek))
-		return 0;
-
 	CheckDZipCompletion ();
 	if (dz_unpacking)
+		return 0;
+
+	if (seek_time < 0 && (cl.paused & 2 || demoui_dragging_seek))
 		return 0;
 
 	if (cls.demoplayback)


### PR DESCRIPTION
Repro steps:
- Find a dz file that does not have an already extracted dem file.
- Start quake and run `playdemo foo.dz` where foo is the name of the dz file.
- Pause.
- Run the playdemo command again.

Quake should now get stuck at the console after extracting the demo. Run the playdemo command *again* and Quake will crash.

The game gets stuck at the console because Quake does not check for completed dzip extraction while the game is paused.  The fix swaps around the check for dzip extraction and the game being paused.