### PR TITLE
r2m8 timing ends on a cutscene

### DIFF
--- a/trunk/ghost/ghostparse.c
+++ b/trunk/ghost/ghostparse.c
@@ -56,9 +56,10 @@ typedef struct {
 
 // on some maps an svc_cutscene message is sent when the level is finished
 // we need to handle such scenarios as if svc_intermission was sent
-static char *cutscene_maps[2] = {
+static char *cutscene_maps[] = {
     "hipend",
     "mexx8",
+    "r2m8",
 };
 
 qboolean MapHasCutsceneAsIntermission(char *map_name)


### PR DESCRIPTION
For the ghost to work properly, levels that end on a cutscene need to be explicitly listed.  See this discussion for more info:

https://github.com/j0zzz/JoeQuake/issues/127

r2m8 is a level where timing ends on a cutscene, which is then followed by some "CONGRATULATIONS" text later.  Without this fix the ending is treated as being on the congratulations text, so the timing is out compared to that reported by DoE qdqstats.  For some demos such as rog_1657, the congratulations text doesn't appear at all so the ghost comparison never even appears.