### PR TITLE
do not interpolate bounding boxes

### DIFF
--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -1832,7 +1832,7 @@ void R_DrawEntBbox(entity_t *ent)
 				break;
 
 		if (range->frame_max == 0)
-			R_DrawBbox(ent->origin, bbox_info->mins, bbox_info->maxs);
+			R_DrawBbox(ent->msg_origins[1], bbox_info->mins, bbox_info->maxs);
 	}
 }
 


### PR DESCRIPTION
cl_bbox is meant for showing exact entity bounds.  It doesn't IMO make sense to interpolate the position.  Practical differences mean that trigger skips, and DKs passing through grenades can be understood without having to turn off interpolation for the model too.