### PR TITLE
fix bbox interp

### DIFF
--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -1818,6 +1818,7 @@ static void R_DrawBbox(vec3_t origin, vec3_t mins, vec3_t maxs)
 
 void R_DrawEntBbox(entity_t *ent)
 {
+	float *origin;
 	frame_range_t *range;
 	id1_bbox_t *bbox_info;
 
@@ -1832,7 +1833,13 @@ void R_DrawEntBbox(entity_t *ent)
 				break;
 
 		if (range->frame_max == 0)
-			R_DrawBbox(ent->msg_origins[1], bbox_info->mins, bbox_info->maxs);
+		{
+			if (gl_interpolate_moves.value)
+				origin = ent->origin;
+			else
+				origin = ent->msg_origins[0];
+			R_DrawBbox(origin, bbox_info->mins, bbox_info->maxs);
+		}
 	}
 }
 


### PR DESCRIPTION
make bbox interpolation enable-able, and use the latest origin if not using interpolation.

It's a lot less jarring when using orbit mode (coming up) if interpolation is enabled, and also using the previous frame (`msg_origins[1]`) is just plain wrong --- when paused you end up with the bbox being lagged one frame relative to the player model.