### PR TITLE
Add orbit mode for demos

### DIFF
--- a/Windows/VisualStudio/JoeQuake.vcxproj
+++ b/Windows/VisualStudio/JoeQuake.vcxproj
@@ -597,7 +597,7 @@
     <ClCompile Include="..\..\trunk\world.c" />
     <ClCompile Include="..\..\trunk\zone.c" />
     <ClCompile Include="..\..\trunk\sys_win.c" />
-    <ClCompile Include="..\..\trunk\freefly.c" />
+    <ClCompile Include="..\..\trunk\democam.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\trunk\fakegl.h" />

--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -330,9 +330,20 @@ Server and Client framerates are independent. This setting is turned on by defau
 +set cl_independentphysics 0
 ```
 
-##### `freefly_speed`
+##### `democam_mode`
 
-Set the speed the camera moves when in freefly mode.  `800` by default.
+Set the camera mode for demo playback.  This is an alternative to using the
+`freefly` and `orbit` toggles:
+
+- `0`:  First person mode.
+- `1`:  Freefly mode. See the `freefly` command for details.
+- `2`:  Orbit mode. See the `orbit` command for details.
+
+##### `freefly_speed`
+##### `orbit_speed`
+
+Set the speed the camera moves when in freefly or orbit mode (respectively).
+`800` / `200` by default.
 
 ##### `freefly_show_pos`
 ##### `freefly_show_pos_x`
@@ -1126,23 +1137,28 @@ Overrides the default `15` (NetQuake) protocol version with given value. Recogni
 This command primarly aims to keep JoeQuake compatible with mods.
 
 ##### `freefly`
+##### `orbit`
 
-Toggle freefly mode.  This is a free flying third-person camera that can be used
-during demo playback.  When enabled, the usual inputs will manipulate the
-camera's position and angle (`+moveleft`, `+moveright`, `+forward`, `+back`,
-mouse movements, etc).
+Toggle freefly / orbit mode.  Freefly is a free flying third-person camera that
+can be used during demo playback.  When enabled, the usual inputs will
+manipulate the camera's position and angle (`+moveleft`, `+moveright`,
+`+forward`, `+back`, mouse movements, etc).
 
-If the demo UI is enabled (`cl_demoui 1`) then click and drag with mouse2 to
-change the camera angle, or bind `+freeflymlook` (see below).  If the demo UI is
-disabled (`cl_demoui 0`) then mouse movements will effect the camera angle
-without need for extra key or button presses.
+Orbit is a camera that is locked to have the player in the centre of the screen.
+When enabled `+forward` and `+back` will move the camera closer and further from
+the player, and mouse movements will change the angle.
+
+In either mode, if the demo UI is enabled (`cl_demoui 1`) then click and drag
+with mouse2 to change the camera angle, or bind `+freeflymlook` (see below).  If
+the demo UI is disabled (`cl_demoui 0`) then mouse movements will effect the
+camera angle without need for extra key or button presses.
 
 ##### `+freeflymlook` / `-freeflymlook`
 
-When using freefly mode with the demo UI, this command makes mouse movements
-adjust the camera angle.  Use this as an alternative to mouse2.  You'll
-typically want to bind this to a key, which should be held down to adjust the
-camera angle.
+When using freefly or orbit mode with the demo UI, this command makes mouse
+movements adjust the camera angle.  Use this as an alternative to mouse2.
+You'll typically want to bind this to a key, which should be held down to adjust
+the camera angle.
 
 ##### `freefly_copycam`
 

--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -1152,6 +1152,8 @@ Set the camera mode for demo playback.  This is an alternative to using the
 - `0`:  First person mode.
 - `1`:  Freefly mode. See the `freefly` command for details.
 - `2`:  Orbit mode. See the `orbit` command for details.
+- `+1`: Cycle forward through modes.
+- `-1`: Cycle backwards through modes.
 
 ##### `+freeflymlook` / `-freeflymlook`
 

--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -330,15 +330,6 @@ Server and Client framerates are independent. This setting is turned on by defau
 +set cl_independentphysics 0
 ```
 
-##### `democam_mode`
-
-Set the camera mode for demo playback.  This is an alternative to using the
-`freefly` and `orbit` toggles:
-
-- `0`:  First person mode.
-- `1`:  Freefly mode. See the `freefly` command for details.
-- `2`:  Orbit mode. See the `orbit` command for details.
-
 ##### `freefly_speed`
 ##### `orbit_speed`
 
@@ -1152,6 +1143,15 @@ In either mode, if the demo UI is enabled (`cl_demoui 1`) then click and drag
 with mouse2 to change the camera angle, or bind `+freeflymlook` (see below).  If
 the demo UI is disabled (`cl_demoui 0`) then mouse movements will effect the
 camera angle without need for extra key or button presses.
+
+##### `democam_mode`
+
+Set the camera mode for demo playback.  This is an alternative to using the
+`freefly` and `orbit` toggles:
+
+- `0`:  First person mode.
+- `1`:  Freefly mode. See the `freefly` command for details.
+- `2`:  Orbit mode. See the `orbit` command for details.
 
 ##### `+freeflymlook` / `-freeflymlook`
 

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -269,9 +269,9 @@ ChangeCam (int dir)
 	}
 	else
 	{
-		mode--;
 		if (mode == 0)
 			mode = DEMOCAM_MODE_COUNT;
+		mode--;
 	}
 
 	snprintf(cmd, sizeof(cmd), "democam_mode %d", mode);

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -254,31 +254,6 @@ UpdateHover (layout_t *layout, const mouse_state_t* ms)
 }
 
 
-static void
-ChangeCam (int dir)
-{
-	char cmd[64];
-	democam_mode_t mode;
-
-	mode = cl.democam_mode;
-	if (dir > 0)
-	{
-		mode++;
-		if (mode == DEMOCAM_MODE_COUNT)
-			mode = 0;
-	}
-	else
-	{
-		if (mode == 0)
-			mode = DEMOCAM_MODE_COUNT;
-		mode--;
-	}
-
-	snprintf(cmd, sizeof(cmd), "democam_mode %d", mode);
-	Cmd_ExecuteString(cmd, src_command);
-}
-
-
 qboolean DemoUI_MouseEvent(const mouse_state_t* ms)
 {
 	char command[64];
@@ -329,7 +304,7 @@ qboolean DemoUI_MouseEvent(const mouse_state_t* ms)
 			case HOVER_SPEED_PREV:
 				ChangeSpeed(-1); break;
 			case HOVER_CAM:
-				ChangeCam(1); break;
+				Cmd_ExecuteString("democam_mode +1", src_command);  break;
 			default:
 				handled = false; break;
 		}
@@ -370,9 +345,9 @@ qboolean DemoUI_MouseEvent(const mouse_state_t* ms)
 				break;
 			case HOVER_CAM:
 				if (ms->button_down == K_MWHEELUP)
-					ChangeCam(-1);
+					Cmd_ExecuteString("democam_mode -1", src_command);
 				else
-					ChangeCam(1);
+					Cmd_ExecuteString("democam_mode +1", src_command);
 				break;
 			default:
 				handled = false; break;

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -1452,7 +1452,7 @@ void CL_Init (void)
 	CL_InitTEnts ();
 	Ghost_Init ();
 	CL_InitDemo ();
-	FreeFly_Init ();
+	DemoCam_Init ();
 
 // register our commands
 	Cvar_Register (&cl_name);

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -1206,7 +1206,8 @@ void CL_RelinkEntities (void)
 		}
 #endif
 
-		if (i == cl.viewentity && !cl_thirdperson.value && !cl.freefly_enabled)
+		if (i == cl.viewentity && !cl_thirdperson.value
+				&& cl.democam_mode == DEMOCAM_MODE_FIRST_PERSON)
 			continue;
 
 		// nehahra support

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -172,6 +172,8 @@ void CL_ClearState (void)
 		cl.free_efrags[i].entnext = &cl.free_efrags[i+1];
 	cl.free_efrags[i].entnext = NULL;
 
+	DemoCam_InitClient();
+
 #ifdef GLQUAKE
 	if (nehahra)
 		SHOWLMP_clear ();

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -122,6 +122,15 @@ typedef enum
 } cactive_t;
 
 
+typedef enum
+{
+	DEMOCAM_MODE_FIRST_PERSON,
+	DEMOCAM_MODE_FREEFLY,
+	DEMOCAM_MODE_ORBIT,
+	DEMOCAM_MODE_COUNT,
+} democam_mode_t;
+
+
 // the client_static_t structure is persistant through an arbitrary number
 // of server connections
 typedef struct
@@ -249,11 +258,12 @@ typedef struct
 	unsigned	protocolflags;
 
 // freefly
-	qboolean	freefly_enabled;
-	qboolean	freefly_reset;
-	double		freefly_last_time;
-	vec3_t		freefly_origin;
-	vec3_t		freefly_angles;
+	democam_mode_t	democam_mode;
+	qboolean	democam_freefly_reset;
+	double		democam_last_time;
+	vec3_t		democam_freefly_origin;
+	float		democam_orbit_distance;
+	vec3_t		democam_angles;
 
 	float		zoom;
 	float		zoomdir;

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -262,8 +262,9 @@ typedef struct
 	qboolean	democam_freefly_reset;
 	double		democam_last_time;
 	vec3_t		democam_freefly_origin;
+	vec3_t		democam_freefly_angles;
 	float		democam_orbit_distance;
-	vec3_t		democam_angles;
+	vec3_t		democam_orbit_angles;
 
 	float		zoom;
 	float		zoomdir;
@@ -517,6 +518,7 @@ void DZip_Cleanup(dzip_context_t *ctx);
 
 // democam.c
 void DemoCam_Init (void);
+void DemoCam_InitClient (void);
 void DemoCam_UpdateOrigin (void);
 void DemoCam_MouseMove (double x, double y);
 void DemoCam_SetRefdef (void);

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -505,13 +505,13 @@ dzip_status_t DZip_Open(dzip_context_t *ctx, const char *name, FILE **demo_file_
 void DZip_Cleanup(dzip_context_t *ctx);
 
 
-// cl_freefly.c
-void FreeFly_Init (void);
-void FreeFly_UpdateOrigin (void);
-void FreeFly_MouseMove (double x, double y);
-void FreeFly_SetRefdef (void);
-qboolean FreeFly_MLook (void);
-void FreeFly_DrawPos (void);
+// democam.c
+void DemoCam_Init (void);
+void DemoCam_UpdateOrigin (void);
+void DemoCam_MouseMove (double x, double y);
+void DemoCam_SetRefdef (void);
+qboolean DemoCam_MLook (void);
+void DemoCam_DrawPos (void);
 
 #ifdef GLQUAKE
 dlighttype_t SetDlightColor (float f, dlighttype_t def, qboolean random);

--- a/trunk/democam.c
+++ b/trunk/democam.c
@@ -38,7 +38,8 @@ static void DemoCam_SetMode (democam_mode_t mode)
 
 static void DemoCam_Mode_f (void)
 {
-	int int_val;
+
+	democam_mode_t next_mode;
 
 	if (!cls.demoplayback)
 	{
@@ -50,24 +51,38 @@ static void DemoCam_Mode_f (void)
 	{
 		Con_Printf("Camera mode is: %d\n"
 					"Usage:\n"
-					" %s   : show current mode\n"
-					" %s 0 : set first person mode\n"
-					" %s 1 : set freefly mode\n"
-					" %s 2 : set orbit mode\n",
+					" %s    : show current mode\n"
+					" %s 0  : set first person mode\n"
+					" %s 1  : set freefly mode\n"
+					" %s 2  : set orbit mode\n",
+					" %s +1 : cycle forwards through modes\n",
+					" %s -1 : cycle backwards through modes\n",
 					cl.democam_mode,
 					Cmd_Argv(0), Cmd_Argv(0), Cmd_Argv(0), Cmd_Argv(0));
 		return;
 	}
 
-	int_val = Q_atoi(Cmd_Argv(1));
-
-	if (int_val >= DEMOCAM_MODE_COUNT || int_val < 0)
+	if (!strcmp(Cmd_Argv(1), "+1"))
 	{
-		Con_Printf("Invalid camera mode %d\n", int_val);
-		return;
+		if (cl.democam_mode == DEMOCAM_MODE_COUNT - 1)
+			next_mode = 0;
+		else
+			next_mode = cl.democam_mode + 1;
+	} else if (!strcmp(Cmd_Argv(1), "-1")) {
+		if (cl.democam_mode == 0)
+			next_mode = DEMOCAM_MODE_COUNT - 1;
+		else
+			next_mode = cl.democam_mode - 1;
+	} else {
+		next_mode = Q_atoi(Cmd_Argv(1));
+		if (next_mode >= DEMOCAM_MODE_COUNT || next_mode < 0)
+		{
+			Con_Printf("Invalid camera mode %d\n", next_mode);
+			return;
+		}
 	}
 
-	DemoCam_SetMode (int_val);
+	DemoCam_SetMode (next_mode);
 }
 
 

--- a/trunk/democam.c
+++ b/trunk/democam.c
@@ -8,6 +8,7 @@ static cvar_t	democam_freefly_show_pos = {"freefly_show_pos", "0"};
 static cvar_t	democam_freefly_show_pos_x = { "freefly_show_pos_x", "-5" }; 
 static cvar_t	democam_freefly_show_pos_y = { "freefly_show_pos_y", "-3" };
 static cvar_t	democam_freefly_show_pos_dp = {"freefly_show_pos_dp", "1"};
+static cvar_t	democam_orbit_speed = {"orbit_speed", "200"};
 
 extern kbutton_t	in_freeflymlook, in_forward, in_back, in_moveleft, in_moveright, in_up, in_down, in_jump;
 
@@ -286,7 +287,7 @@ void DemoCam_UpdateOrigin (void)
 	}
 	else if (cl.democam_mode == DEMOCAM_MODE_ORBIT)
 	{
-		cl.democam_orbit_distance += -democam_freefly_speed.value * frametime
+		cl.democam_orbit_distance += -democam_orbit_speed.value * frametime
 			* (CL_KeyState(&in_forward) - CL_KeyState(&in_back));
 		cl.democam_orbit_distance = max(0, cl.democam_orbit_distance);
 	}
@@ -327,6 +328,7 @@ void DemoCam_Init (void)
 	Cvar_Register(&democam_freefly_show_pos_x);
 	Cvar_Register(&democam_freefly_show_pos_y);
 	Cvar_Register(&democam_freefly_show_pos_dp);
+	Cvar_Register(&democam_orbit_speed);
 	Cvar_Register(&democam_mode);
 
 	Cmd_AddCommand("freefly", DemoCam_Toggle_f);

--- a/trunk/democam.c
+++ b/trunk/democam.c
@@ -1,15 +1,15 @@
 #include "quakedef.h"
 
 
-cvar_t	freefly_speed = {"freefly_speed", "800"};
-cvar_t	freefly_show_pos = {"freefly_show_pos", "0"};
-cvar_t  freefly_show_pos_x = { "freefly_show_pos_x", "-5" }; 
-cvar_t  freefly_show_pos_y = { "freefly_show_pos_y", "-3" };
-cvar_t  freefly_show_pos_dp = {"freefly_show_pos_dp", "1"};
+cvar_t	democam_freefly_speed = {"democam_freefly_speed", "800"};
+cvar_t	democam_freefly_show_pos = {"freefly_show_pos", "0"};
+cvar_t  democam_freefly_show_pos_x = { "freefly_show_pos_x", "-5" }; 
+cvar_t  democam_freefly_show_pos_y = { "freefly_show_pos_y", "-3" };
+cvar_t  democam_freefly_show_pos_dp = {"freefly_show_pos_dp", "1"};
 
 extern kbutton_t	in_freeflymlook, in_forward, in_back, in_moveleft, in_moveright, in_up, in_down, in_jump;
 
-static void FreeFly_Toggle_f (void)
+static void DemoCam_Toggle_f (void)
 {
 	if (!cls.demoplayback)
 	{
@@ -34,7 +34,7 @@ static void FreeFly_Toggle_f (void)
 }
 
 
-static char *FreeFly_GetRemaicCommand (const char *arg)
+static char *DemoCam_GetRemaicCommand (const char *arg)
 {
 	trace_t	trace;
 	vec3_t	forward, right, up, end;
@@ -99,7 +99,7 @@ static char *FreeFly_GetRemaicCommand (const char *arg)
 }
 
 
-static void FreeFly_WriteCam_f (void)
+static void DemoCam_WriteCam_f (void)
 {
 	char path[MAX_OSPATH];
 	char *cmd;
@@ -119,7 +119,7 @@ static void FreeFly_WriteCam_f (void)
 		arg = Cmd_Argv(2);
 	}
 
-	cmd = FreeFly_GetRemaicCommand(arg);
+	cmd = DemoCam_GetRemaicCommand(arg);
 	if (cmd == NULL)
 		return;
 
@@ -140,7 +140,7 @@ static void FreeFly_WriteCam_f (void)
 }
 
 
-static void FreeFly_CopyCam_f (void)
+static void DemoCam_CopyCam_f (void)
 {
 	char *cmd;
 	const char *arg;
@@ -152,21 +152,21 @@ static void FreeFly_CopyCam_f (void)
 		arg = Cmd_Argv(1);
 	}
 
-	cmd = FreeFly_GetRemaicCommand(arg);
+	cmd = DemoCam_GetRemaicCommand(arg);
 
 	if (cmd != NULL && Sys_SetClipboardData(cmd))
 		Con_Printf("Remaic commands copy to clipboard:\n%s", cmd);
 }
 
 
-qboolean FreeFly_MLook (void)
+qboolean DemoCam_MLook (void)
 {
 	return cl.freefly_enabled
 		&& (cl_demoui.value == 0 || (in_freeflymlook.state & 1) || demoui_freefly_mlook);
 }
 
 
-void FreeFly_SetRefdef (void)
+void DemoCam_SetRefdef (void)
 {
     if (!cls.demoplayback)
         cl.freefly_enabled = false;
@@ -187,9 +187,9 @@ void FreeFly_SetRefdef (void)
 }
 
 
-void FreeFly_MouseMove (double x, double y)
+void DemoCam_MouseMove (double x, double y)
 {
-	if (!FreeFly_MLook())
+	if (!DemoCam_MLook())
 		return;
 
 	cl.freefly_angles[YAW] -= m_yaw.value * x;
@@ -198,7 +198,7 @@ void FreeFly_MouseMove (double x, double y)
 }
 
 
-void FreeFly_UpdateOrigin (void)
+void DemoCam_UpdateOrigin (void)
 {
 	double time, frametime;
 	vec3_t forward, right, up, vel;
@@ -226,22 +226,23 @@ void FreeFly_UpdateOrigin (void)
 			 world_up,
 			 vel);
 	VectorNormalize(vel);
-	VectorScale(vel, freefly_speed.value, vel);
+	VectorScale(vel, democam_freefly_speed.value, vel);
 	VectorMA(cl.freefly_origin, frametime, vel, cl.freefly_origin);
 }
 
 
-void FreeFly_DrawPos (void)
+void DemoCam_DrawPos (void)
 {
 	int x, y;
 	int dp;
 	char str[128];
 	vec3_t pos;
 
-	if (cls.state != ca_connected || !cl.freefly_enabled || !freefly_show_pos.value)
+	if (cls.state != ca_connected || !cl.freefly_enabled
+			|| !democam_freefly_show_pos.value)
 		return;
 
-	dp = (int)freefly_show_pos_dp.value;
+	dp = (int)democam_freefly_show_pos_dp.value;
 	VectorCopy(cl.freefly_origin, pos);
 	pos[2] -= DEFAULT_VIEWHEIGHT;
 
@@ -250,21 +251,21 @@ void FreeFly_DrawPos (void)
 				dp + 6, dp, pos[1],
 				dp + 6, dp, pos[2]);
 
-	x = ELEMENT_X_COORD(freefly_show_pos);
-	y = ELEMENT_Y_COORD(freefly_show_pos);
+	x = ELEMENT_X_COORD(democam_freefly_show_pos);
+	y = ELEMENT_Y_COORD(democam_freefly_show_pos);
 	Draw_String (x, y, str, true);
 }
 
 
-void FreeFly_Init (void)
+void DemoCam_Init (void)
 {
-	Cvar_Register(&freefly_speed);
-	Cvar_Register(&freefly_show_pos);
-	Cvar_Register(&freefly_show_pos_x);
-	Cvar_Register(&freefly_show_pos_y);
-	Cvar_Register(&freefly_show_pos_dp);
+	Cvar_Register(&democam_freefly_speed);
+	Cvar_Register(&democam_freefly_show_pos);
+	Cvar_Register(&democam_freefly_show_pos_x);
+	Cvar_Register(&democam_freefly_show_pos_y);
+	Cvar_Register(&democam_freefly_show_pos_dp);
 
-	Cmd_AddCommand("freefly", FreeFly_Toggle_f);
-	Cmd_AddCommand("freefly_copycam", FreeFly_CopyCam_f);
-	Cmd_AddCommand("freefly_writecam", FreeFly_WriteCam_f);
+	Cmd_AddCommand("freefly", DemoCam_Toggle_f);
+	Cmd_AddCommand("freefly_copycam", DemoCam_CopyCam_f);
+	Cmd_AddCommand("freefly_writecam", DemoCam_WriteCam_f);
 }

--- a/trunk/democam.c
+++ b/trunk/democam.c
@@ -52,7 +52,7 @@ static qboolean DemoCam_CameraModeChange (struct cvar_s *var, char *value)
 }
 
 
-static void DemoCam_Toggle_f (void)
+static void DemoCam_FreeFly_Toggle_f (void)
 {
 	if (!cls.demoplayback)
 	{
@@ -331,7 +331,7 @@ void DemoCam_Init (void)
 	Cvar_Register(&democam_orbit_speed);
 	Cvar_Register(&democam_mode);
 
-	Cmd_AddCommand("freefly", DemoCam_Toggle_f);
+	Cmd_AddCommand("freefly", DemoCam_FreeFly_Toggle_f);
 	Cmd_AddCommand("orbit", DemoCam_Orbit_Toggle_f);
 	Cmd_AddCommand("freefly_copycam", DemoCam_CopyCam_f);
 	Cmd_AddCommand("freefly_writecam", DemoCam_WriteCam_f);

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -3498,7 +3498,7 @@ void R_DrawViewModel (void)
 {
 	currententity = &cl.viewent;
 
-	if (!r_drawviewmodel.value || cl.freefly_enabled || cl_thirdperson.value || !r_drawentities.value || 
+	if (!r_drawviewmodel.value || cl.democam_mode != DEMOCAM_MODE_FIRST_PERSON || cl_thirdperson.value || !r_drawentities.value || 
 	    (cl.stats[STAT_HEALTH] <= 0) || !currententity->model)
 		return;
 

--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -1061,7 +1061,7 @@ static void SCR_DrawCursor(void)
 	cursor_y = scr_pointer_state.y;
 
 	// Disable the cursor in all but following client parts
-	if ((CL_DemoUIOpen() && FreeFly_MLook()) || (!CL_DemoUIOpen() && key_dest != key_menu))
+	if ((CL_DemoUIOpen() && DemoCam_MLook()) || (!CL_DemoUIOpen() && key_dest != key_menu))
 		return;
 
 	if (scr_pointer_state.x != scr_pointer_state.x_old || scr_pointer_state.y != scr_pointer_state.y_old)
@@ -1260,7 +1260,7 @@ void SCR_UpdateScreen (void)
 		Sbar_Draw ();
 		SCR_DrawConsole ();
 		M_Draw ();
-		FreeFly_DrawPos ();
+		DemoCam_DrawPos ();
 	}
 
 	if (CL_DemoUIOpen() && key_dest == key_game)

--- a/trunk/gl_screen.c
+++ b/trunk/gl_screen.c
@@ -782,7 +782,7 @@ void SCR_SetupAutoID (void)
 
 		if (state == &cl_entities[cl.viewentity] &&
 				cl_thirdperson.value == 0 &&
-				!cl.freefly_enabled)
+				cl.democam_mode == DEMOCAM_MODE_FIRST_PERSON)
 		{
 			continue;
 		}

--- a/trunk/host.c
+++ b/trunk/host.c
@@ -806,7 +806,7 @@ void _Host_Frame (double time)
 		}
 	}
 
-	FreeFly_UpdateOrigin();
+	DemoCam_UpdateOrigin();
 
 	if (host_speeds.value)
 		time1 = Sys_DoubleTime ();

--- a/trunk/in_sdl.c
+++ b/trunk/in_sdl.c
@@ -278,7 +278,7 @@ static void IN_MouseMove (usercmd_t *cmd)
 		float mousespeed = sqrt(mx * mx + my * my);
 		float m_accel_factor = m_accel.value * 0.1;
 
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_MLook()))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !DemoCam_MLook()))
 		{
 			mouse_x *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
 			mouse_y *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
@@ -294,7 +294,7 @@ static void IN_MouseMove (usercmd_t *cmd)
 	}
 	else
 	{
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_MLook()))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !DemoCam_MLook()))
 		{
 			mouse_x *= cursor_sensitivity.value;
 			mouse_y *= cursor_sensitivity.value;
@@ -310,7 +310,7 @@ static void IN_MouseMove (usercmd_t *cmd)
 	}
 
 	if (key_dest != key_menu && key_dest != key_console)
-		FreeFly_MouseMove(mouse_x, mouse_y);
+		DemoCam_MouseMove(mouse_x, mouse_y);
 
 	//
 	// Do not move the player if we're in menu mode.

--- a/trunk/in_win.c
+++ b/trunk/in_win.c
@@ -1112,7 +1112,7 @@ void IN_MouseMove (usercmd_t *cmd)
 		float mousespeed = sqrt(mx * mx + my * my);
 		float m_accel_factor = m_accel.value * 0.1;
 
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_MLook()))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !DemoCam_MLook()))
 		{
 			mouse_x *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
 			mouse_y *= ((mousespeed * m_accel_factor) + cursor_sensitivity.value);
@@ -1128,7 +1128,7 @@ void IN_MouseMove (usercmd_t *cmd)
 	}
 	else
 	{
-		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !FreeFly_MLook()))
+		if (key_dest == key_menu || key_dest == key_console || (CL_DemoUIOpen() && !DemoCam_MLook()))
 		{
 			mouse_x *= cursor_sensitivity.value;
 			mouse_y *= cursor_sensitivity.value;
@@ -1144,7 +1144,7 @@ void IN_MouseMove (usercmd_t *cmd)
 	}
 
 	if (key_dest != key_menu && key_dest != key_console)
-		FreeFly_MouseMove(mouse_x, mouse_y);
+		DemoCam_MouseMove(mouse_x, mouse_y);
 
 	//
 	// Do not move the player if we're in menu mode. 

--- a/trunk/r_main.c
+++ b/trunk/r_main.c
@@ -603,7 +603,7 @@ void R_DrawViewModel (void)
 
 	currententity = &cl.viewent;
 
-	if (!r_drawviewmodel.value || cl.freefly_enabled || cl_thirdperson.value || !r_drawentities.value || 
+	if (!r_drawviewmodel.value || cl.democam_mode != DEMOCAM_MODE_FIRST_PERSON || cl_thirdperson.value || !r_drawentities.value || 
 	    (cl.items & IT_INVISIBILITY) || (cl.stats[STAT_HEALTH] <= 0) || !currententity->model)
 		return;
 

--- a/trunk/view.c
+++ b/trunk/view.c
@@ -1078,7 +1078,7 @@ void V_CalcIntermissionRefdef (void)
 	V_AddIdle ();
 	v_idlescale.value = old;
 
-	FreeFly_SetRefdef ();
+	DemoCam_SetRefdef ();
 
 }
 
@@ -1153,7 +1153,7 @@ void V_CalcRefdef (void)
 	if (cl_thirdperson.value)
 		Chase_Update ();
 
-	FreeFly_SetRefdef ();
+	DemoCam_SetRefdef ();
 
 // bound minpitch/maxpitch
 	if (cl_minpitch.value < -90)


### PR DESCRIPTION
Here's a new sibling feature for freefly:  orbit mode.  As per the docs:
> Orbit is a camera that is locked to have the player in the centre of the screen.
When enabled `+forward` and `+back` will move the camera closer and further from
the player, and mouse movements will change the angle.

...and here is a video of it in action: https://www.youtube.com/watch?v=3K6nk_RsAOI

In combination with `cl_bbox 1` this mode can be useful to check for near collisions.  To stop the bounding box jittering when in motion, make sure `gl_interpolate_movement` is set to 0. 

As part of this PR I renamed `freefly.c` to `democam.c`.  This makes the changes to this file hard to read since the whole file appears as a single addition.  To help with this, I did the rename in an [initial commit](https://github.com/matthewearl/joequake-1/commit/450ddfbd2c0c8fd9f487bcbcae1fb6c1fa0e5719) and everything else can be seen in [this diff](https://github.com/j0zzz/JoeQuake/compare/450ddfbd2c0c8fd9f487bcbcae1fb6c1fa0e5719...matthewearl:JoeQuake-1:orbit?expand=1).   You might find it easier to look at these two change sets separately when reviewing.

