### PR TITLE
sv_novis

### DIFF
--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -379,6 +379,17 @@ This allows to set starting stats for when starting levels with the `map` or `re
 Dedicated max speed value used only while noclip.
 Its value is `320` by default.
 
+##### `sv_novis`
+
+When set to 1, entities are not PVS culled before being sent to the client.  In
+practice this means that all enemies are visible when `r_outline_monsters` is
+used, and that all monsters are recorded in demos.  The latter is useful for
+being able to see entities that the player can't see in recams or when using the
+freefly feature.
+
+This naturally inflates demo size, so be careful using it with entity heavy
+maps.
+
 #### Network
 
 ##### `net_connectsearch`

--- a/trunk/sv_main.c
+++ b/trunk/sv_main.c
@@ -604,10 +604,11 @@ void SV_WriteEntitiesToClient (edict_t *clent, sizebuf_t *msg, qboolean nomap)
 				if (i == ent->num_leafs && ent->num_leafs < MAX_ENT_LEAFS)
 					continue;		// not visible
 
-				// joe, from ProQuake: don't send updates if the client doesn't have the map
-				if (nomap)
-					continue;
 			}
+
+			// joe, from ProQuake: don't send updates if the client doesn't have the map
+			if (nomap)
+				continue;
 		}
 
 		//johnfitz -- max size for protocol 15 is 18 bytes, not 16 as originally


### PR DESCRIPTION
Implement `sv_novis`.   This is similar to `r_novis` except it controls which entities are sent from the server.  It is therefore useful for:
- wallhacking missing enemies in 100% run.
- capturing the full level in a demo, useful for recams and freefly.

`sv_novis 0`:
![image](https://github.com/user-attachments/assets/e9390fb3-02be-47f7-809a-697963da150f)
`sv_novis 1`:

![image](https://github.com/user-attachments/assets/2cace808-f32a-44e3-a4c9-0c10a454f946)

