### PR TITLE
fix ghost bbox when interp is off

### DIFF
--- a/trunk/ghost/ghost.c
+++ b/trunk/ghost/ghost.c
@@ -427,6 +427,8 @@ static qboolean Ghost_Update (void)
         // TODO: lerp animation frames
         ghost_entity.frame = rec_after->frame;
 
+        VectorCopy(rec_before->origin, ghost_entity.msg_origins[0]);
+        VectorCopy(rec_after->origin, ghost_entity.msg_origins[1]);
         Ghost_LerpOrigin(rec_before->origin, rec_after->origin,
                          frac,
                          ghost_entity.origin);
@@ -476,6 +478,7 @@ void Ghost_Draw (void)
      *  - skinnum
      *  - colormap
      *  - transparency
+     *  - msg_origins
      *  - origin
      *  - angles
      *  - modelindex


### PR DESCRIPTION
cl_bbox reads msg_origins[0] when gl_interpolate_movement is 0, but this field was not being set on the ghost entity.  As a result the ghost bbox was being drawn at the origin when interpolation was turned off.