### PR TITLE
cl_bbox improvements

### DIFF
--- a/docs/_includes/subfeatures/demo-ui.md
+++ b/docs/_includes/subfeatures/demo-ui.md
@@ -14,7 +14,9 @@ The interface has the following elements, from bottom-to-top, left-to-right:
   map.
 - **Speed**: Increase and decrease demo playback speed by clicking the arrow
   controls or by using the mouse wheel in this area.
-- **Freefly mode (FF)**: Toggles between freefly camera and first-person camera mode.
+- **Bounding boxes (BB)**: Toggle client-side bounding boxes.
+- **Camera mode (CAM)**: Cycles between first-person, freefly, and orbit camera
+  modes.
 - **Map selector**: Shows the current map.  On a multi-map (marathon) demo
   clicking the arrow controls or using the mouse wheel in this area will skip
   from map to map. Click between the arrows to toggle the map menu.

--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -360,6 +360,8 @@ have the following limitations:
   precision in the coordinates sent to the client and stored in the demo.
 - Bounding boxes are not displayed when *recording* a demo.
 
+Set to 2 to make the boxes white rather than being colored according to entity
+
 #### Server
 
 ##### `sv_altnoclip`

--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -347,10 +347,10 @@ The number of decimal places can be changed with the `_dp` variable.
 
 ##### `cl_bbox`
 
-When set to 1 display bounding boxes for non-map entities. The bounding boxes
-are derived from information available to the client, therefore they work while
-playing a demo as well as when playing a live game. However, the bounding boxes
-have the following limitations:
+Enables bounding boxes for non-map entities. The bounding boxes are derived from
+information available to the client, therefore they work while playing a demo as
+well as when playing a live game. However, the bounding boxes have the following
+limitations:
 
 - If using non-id1 progs, bounding boxes may be missing or incorrect.  This is
   unavoidable since bounding box information is not sent to the client or stored
@@ -360,7 +360,22 @@ have the following limitations:
   precision in the coordinates sent to the client and stored in the demo.
 - Bounding boxes are not displayed when *recording* a demo.
 
-Set to 2 to make the boxes white rather than being colored according to entity
+The cvar takes the following values:
+- `0`: Bounding boxes are never drawn.
+- `1`: Bounding boxes are drawn during demo playback and when playing live, but
+  not when recording.
+- `2`: Bounding boxes are drawn only during demo playback.
+- `3`: Bounding boxes are drawn only when playing live, but not when recording.
+
+##### `cl_bboxcolors`
+
+When set to `1` (the default), `cl_bbox` bounding boxes are colored according to
+entity type:
+- Monsters are red.
+- Pickups are green.
+- Everything else is white.
+
+When set to `0` bounding boxes are all drawn white.
 
 #### Server
 

--- a/trunk/cl_demoui.c
+++ b/trunk/cl_demoui.c
@@ -73,10 +73,14 @@ ToggleBBox (void)
 {
 	float next_value;
 
-	if (cl_bbox.value  == 0)
-		next_value = 1.0f;
+	if (cl_bbox.value == CL_BBOX_MODE_ON)
+		next_value = CL_BBOX_MODE_LIVE;
+	else if (cl_bbox.value == CL_BBOX_MODE_DEMO)
+		next_value = CL_BBOX_MODE_OFF;
+	else if (cl_bbox.value == CL_BBOX_MODE_LIVE)
+		next_value = CL_BBOX_MODE_ON;
 	else
-		next_value = 0.0f;
+		next_value = CL_BBOX_MODE_DEMO;
 
 	Cvar_SetValue(&cl_bbox, next_value);
 }
@@ -646,10 +650,10 @@ void DemoUI_Draw(void)
 			Draw_String(layout.bbox_x, layout.bbox_y, "BB:", true);
 		else
 			Draw_Alt_String(layout.bbox_x, layout.bbox_y, "BB:", true);
-		if (cl_bbox.value == 0)
-			Draw_String(layout.bbox_x + layout.char_size * 3, layout.cam_y, "0", true);
-		else
+		if (cl_bbox.value == CL_BBOX_MODE_ON || cl_bbox.value == CL_BBOX_MODE_DEMO)
 			Draw_String(layout.bbox_x + layout.char_size * 3, layout.cam_y, "1", true);
+		else
+			Draw_String(layout.bbox_x + layout.char_size * 3, layout.cam_y, "0", true);
 	}
 
 	// Tooltip

--- a/trunk/cl_main.c
+++ b/trunk/cl_main.c
@@ -58,6 +58,7 @@ cvar_t	cl_bobbing = {"cl_bobbing", "0"};
 cvar_t	cl_deadbodyfilter = {"cl_deadbodyfilter", "0"};
 cvar_t	cl_gibfilter = {"cl_gibfilter", "0"};
 cvar_t	cl_bbox = {"cl_bbox", "0"};
+cvar_t	cl_bboxcolors = {"cl_bboxcolors", "1"};
 cvar_t	cl_maxfps = {"cl_maxfps", "72", CVAR_SERVER};
 cvar_t	cl_advancedcompletion = {"cl_advancedcompletion", "1"};
 cvar_t	cl_independentphysics = {"cl_independentphysics", "1", CVAR_INIT};
@@ -740,7 +741,9 @@ void GetQuake3ViewWeaponModel(int *vwep_modelindex)
 
 qboolean CL_ShowBBoxes(void)
 {
-	return cl_bbox.value && !cls.demorecording;
+	qboolean demo_bbox = (cl_bbox.value == CL_BBOX_MODE_ON || cl_bbox.value == CL_BBOX_MODE_DEMO);
+	qboolean live_bbox = (cl_bbox.value == CL_BBOX_MODE_ON || cl_bbox.value == CL_BBOX_MODE_LIVE);
+	return ((demo_bbox && cls.demoplayback) || (live_bbox && !cls.demoplayback)) && !cls.demorecording;
 }
 
 
@@ -1490,6 +1493,7 @@ void CL_Init (void)
 	Cvar_Register (&cl_deadbodyfilter);
 	Cvar_Register (&cl_gibfilter);
 	Cvar_Register (&cl_bbox);
+	Cvar_Register (&cl_bboxcolors);
 	Cvar_Register (&cl_maxfps);
 	Cvar_Register (&cl_advancedcompletion);
 	Cvar_Register (&cl_independentphysics);

--- a/trunk/cl_parse.c
+++ b/trunk/cl_parse.c
@@ -194,6 +194,12 @@ void CL_InitModelnames (void)
 	cl_modelnames[mi_i_end4] = "progs/end4.mdl";
 	cl_modelnames[mi_i_backpack] = "progs/backpack.mdl";
 	cl_modelnames[mi_explobox] = "maps/b_explob.bsp";
+	cl_modelnames[mi_k_spike] = "progs/k_spike.mdl";
+	cl_modelnames[mi_s_spike] = "progs/s_spike.mdl";
+	cl_modelnames[mi_v_spike] = "progs/v_spike.mdl";
+	cl_modelnames[mi_w_spike] = "progs/w_spike.mdl";
+	cl_modelnames[mi_laser] = "progs/laser.mdl";
+	cl_modelnames[mi_spike] = "progs/spike.mdl";
 
 	for (i = 0 ; i < NUM_MODELINDEX ; i++)
 	{

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -379,6 +379,7 @@ typedef	enum modelindex_s {
 	mi_i_wskey, mi_i_mskey, mi_i_wgkey, mi_i_mgkey,
 	mi_i_end1, mi_i_end2, mi_i_end3, mi_i_end4,
 	mi_i_backpack, mi_explobox,
+	mi_k_spike, mi_s_spike, mi_v_spike, mi_w_spike, mi_laser, mi_spike,
 
 	NUM_MODELINDEX
 } modelindex_t;

--- a/trunk/client.h
+++ b/trunk/client.h
@@ -130,6 +130,16 @@ typedef enum
 	DEMOCAM_MODE_COUNT,
 } democam_mode_t;
 
+typedef enum
+{
+	CL_BBOX_MODE_OFF,
+	CL_BBOX_MODE_ON,
+	CL_BBOX_MODE_DEMO,
+	CL_BBOX_MODE_LIVE,
+
+	NUM_BBOX_MODE
+} cl_bbox_mode_t;
+
 
 // the client_static_t structure is persistant through an arbitrary number
 // of server connections
@@ -311,6 +321,7 @@ extern	cvar_t	cl_deadbodyfilter;
 extern	cvar_t	cl_gibfilter;
 extern	cvar_t	cl_confirmquit;
 extern	cvar_t	cl_bbox;
+extern	cvar_t	cl_bboxcolors;
 
 extern	cvar_t	cl_demoui;
 extern	cvar_t	cl_demouitimeout;

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -1928,7 +1928,7 @@ void R_DrawEntBbox(entity_t *ent)
 			else
 				origin = ent->msg_origins[0];
 
-			if (cl_bbox.value < 2)
+			if (cl_bboxcolors.value)
 				VectorCopy(bbox_colors[bbox_info->bbox_cat], color);
 			if (VectorLength(bbox_info->mins) < 1e-2
 					&& VectorLength(bbox_info->maxs) < 1e-2)

--- a/trunk/gl_rmain.c
+++ b/trunk/gl_rmain.c
@@ -188,84 +188,100 @@ typedef struct
 	int frame_max;
 } frame_range_t;
 
+typedef enum
+{
+	BBOX_CAT_MISC,
+	BBOX_CAT_MONSTER,
+	BBOX_CAT_PICKUP,
+
+	NUM_BBOX_CAT
+} bbox_cat_t;
+
 typedef struct
 {
 	modelindex_t mi;
 	vec3_t mins, maxs;
+	bbox_cat_t bbox_cat;
 	frame_range_t not_solid_frames[3];  // null terminated
 } id1_bbox_t;
 
 static id1_bbox_t id1_bboxes[] = {
 	// player
-	{mi_player, {-16, -16, -24}, {16, 16, 32}, {{41, 103}}},
-	{mi_eyes, {-16, -16, -24}, {16, 16, 32}},
+	{mi_player, {-16, -16, -24}, {16, 16, 32}, BBOX_CAT_MISC, {{41, 103}}},
+	{mi_eyes, {-16, -16, -24}, {16, 16, 32}, BBOX_CAT_MISC},
 
 	// monsters
-	{mi_boss, {-128, -128, -24}, {128, 128, 256}},
-	{mi_fiend, {-32, -32, -24}, {32, 32, 64}, {{50, 54}}},
-	{mi_dog, {-32, -32, -24}, {32, 32, 40}, {{8, 26}}},
-	{mi_enforcer, {-16, -16, -24}, {16, 16, 40}, {{43, 55}, {57, 66}}},
-	{mi_fish, {-16, -16, -24}, {16, 16, 24}, {{38, 39}}},
-	{mi_hknight, {-16, -16, -24}, {16, 16, 40}, {{44, 54}, {56, 63}}},
-	{mi_knight, {-16, -16, -24}, {16, 16, 40}, {{78, 86}, {88, 97}}},
-	{mi_ogre, {-32, -32, -24}, {32, 32, 64}, {{114, 126}, {128, 136}}},
-	{mi_oldone, {-160, -128, -24}, {160, 128, 256}},
-	{mi_vore, {-32, -32, -24}, {32, 32, 64}, {{16, 23}}},
-	{mi_shambler, {-32, -32, -24}, {32, 32, 64}, {{85, 94}}},
-	{mi_soldier, {-16, -16, -24}, {16, 16, 40}, {{10, 18}, {20, 29}}},
-	{mi_spawn, {-16, -16, -24}, {16, 16, 40}},
-	{mi_scrag, {-16, -16, -24}, {16, 16, 40}, {{48, 54}}},
-	{mi_zombie, {-16, -16, -24}, {16, 16, 40}, {{171, 173}}},
+	{mi_boss, {-128, -128, -24}, {128, 128, 256}, BBOX_CAT_MONSTER},
+	{mi_fiend, {-32, -32, -24}, {32, 32, 64}, BBOX_CAT_MONSTER, {{50, 54}}},
+	{mi_dog, {-32, -32, -24}, {32, 32, 40}, BBOX_CAT_MONSTER, {{8, 26}}},
+	{mi_enforcer, {-16, -16, -24}, {16, 16, 40}, BBOX_CAT_MONSTER, {{43, 55}, {57, 66}}},
+	{mi_fish, {-16, -16, -24}, {16, 16, 24}, BBOX_CAT_MONSTER, {{38, 39}}},
+	{mi_hknight, {-16, -16, -24}, {16, 16, 40}, BBOX_CAT_MONSTER, {{44, 54}, {56, 63}}},
+	{mi_knight, {-16, -16, -24}, {16, 16, 40}, BBOX_CAT_MONSTER, {{78, 86}, {88, 97}}},
+	{mi_ogre, {-32, -32, -24}, {32, 32, 64}, BBOX_CAT_MONSTER, {{114, 126}, {128, 136}}},
+	{mi_oldone, {-160, -128, -24}, {160, 128, 256}, BBOX_CAT_MONSTER},
+	{mi_vore, {-32, -32, -24}, {32, 32, 64}, BBOX_CAT_MONSTER, {{16, 23}}},
+	{mi_shambler, {-32, -32, -24}, {32, 32, 64}, BBOX_CAT_MONSTER, {{85, 94}}},
+	{mi_soldier, {-16, -16, -24}, {16, 16, 40}, BBOX_CAT_MONSTER, {{10, 18}, {20, 29}}},
+	{mi_spawn, {-16, -16, -24}, {16, 16, 40}, BBOX_CAT_MONSTER},
+	{mi_scrag, {-16, -16, -24}, {16, 16, 40}, BBOX_CAT_MONSTER, {{48, 54}}},
+	{mi_zombie, {-16, -16, -24}, {16, 16, 40}, BBOX_CAT_MONSTER, {{171, 173}}},
 
 	// bsp items
-	{mi_i_bh10, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_bh25, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_bh100, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_shell0, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_shell1, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_nail0, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_nail1, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_rock0, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_rock1, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_batt0, {-16, -16, -1}, {48, 48, 57}},
-	{mi_i_batt1, {-16, -16, -1}, {48, 48, 57}},
+	{mi_i_bh10, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_bh25, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_bh100, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_shell0, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_shell1, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_nail0, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_nail1, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_rock0, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_rock1, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_batt0, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
+	{mi_i_batt1, {-16, -16, -1}, {48, 48, 57}, BBOX_CAT_PICKUP},
 
 	// mdl items
-	{mi_i_quad, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_invuln, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_suit, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_invis, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_armor, {-32, -32, -1}, {32, 32, 57}},
-	{mi_i_shot, {-32, -32, -1}, {32, 32, 57}},
-	{mi_i_nail, {-32, -32, -1}, {32, 32, 57}},
-	{mi_i_nail2, {-32, -32, -1}, {32, 32, 57}},
-	{mi_i_rock, {-32, -32, -1}, {32, 32, 57}},
-	{mi_i_rock2, {-32, -32, -1}, {32, 32, 57}},
-	{mi_i_light, {-32, -32, -1}, {32, 32, 57}},
-	{mi_i_wskey, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_mskey, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_wgkey, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_mgkey, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_end1, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_end2, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_end3, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_end4, {-32, -32, -25}, {32, 32, 33}},
-	{mi_i_backpack, {-32, -32, -1}, {32, 32, 57}},
+	{mi_i_quad, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_invuln, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_suit, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_invis, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_armor, {-32, -32, -1}, {32, 32, 57}, BBOX_CAT_PICKUP},
+	{mi_i_shot, {-32, -32, -1}, {32, 32, 57}, BBOX_CAT_PICKUP},
+	{mi_i_nail, {-32, -32, -1}, {32, 32, 57}, BBOX_CAT_PICKUP},
+	{mi_i_nail2, {-32, -32, -1}, {32, 32, 57}, BBOX_CAT_PICKUP},
+	{mi_i_rock, {-32, -32, -1}, {32, 32, 57}, BBOX_CAT_PICKUP},
+	{mi_i_rock2, {-32, -32, -1}, {32, 32, 57}, BBOX_CAT_PICKUP},
+	{mi_i_light, {-32, -32, -1}, {32, 32, 57}, BBOX_CAT_PICKUP},
+	{mi_i_wskey, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_mskey, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_wgkey, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_mgkey, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_end1, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_end2, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_end3, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_end4, {-32, -32, -25}, {32, 32, 33}, BBOX_CAT_PICKUP},
+	{mi_i_backpack, {-32, -32, -1}, {32, 32, 57}, BBOX_CAT_PICKUP},
 
 	// projectiles
-	{mi_rocket, {0, 0, 0}, {0, 0, 0}},
-	{mi_grenade, {0, 0, 0}, {0, 0, 0}},
-	{mi_k_spike, {0, 0, 0}, {0, 0, 0}},
-	{mi_s_spike, {0, 0, 0}, {0, 0, 0}},
-	{mi_v_spike, {0, 0, 0}, {0, 0, 0}},
-	{mi_w_spike, {0, 0, 0}, {0, 0, 0}},
-	{mi_laser, {0, 0, 0}, {0, 0, 0}},
-	{mi_spike, {0, 0, 0}, {0, 0, 0}},
+	{mi_rocket, {0, 0, 0}, {0, 0, 0}, BBOX_CAT_MISC},
+	{mi_grenade, {0, 0, 0}, {0, 0, 0}, BBOX_CAT_MISC},
+	{mi_k_spike, {0, 0, 0}, {0, 0, 0}, BBOX_CAT_MISC},
+	{mi_s_spike, {0, 0, 0}, {0, 0, 0}, BBOX_CAT_MISC},
+	{mi_v_spike, {0, 0, 0}, {0, 0, 0}, BBOX_CAT_MISC},
+	{mi_w_spike, {0, 0, 0}, {0, 0, 0}, BBOX_CAT_MISC},
+	{mi_laser, {0, 0, 0}, {0, 0, 0}, BBOX_CAT_MISC},
+	{mi_spike, {0, 0, 0}, {0, 0, 0}, BBOX_CAT_MISC},
 
 	// misc
-	{mi_explobox, {0, 0, 0}, {32, 32, 64}},
+	{mi_explobox, {0, 0, 0}, {32, 32, 64}, BBOX_CAT_MISC},
 
 	{NUM_MODELINDEX}
+};
+
+static vec3_t bbox_colors[NUM_BBOX_CAT] = {
+	[BBOX_CAT_MISC] = {1, 1, 1},
+	[BBOX_CAT_MONSTER] = {1, 0, 0},
+	[BBOX_CAT_PICKUP] = {0, 1, 0},
 };
 
 void R_MarkSurfaces(void);
@@ -1772,7 +1788,7 @@ void R_SetupInterpolateDistance (entity_t *ent, aliashdr_t *paliashdr, int *dist
 	}
 }
 
-static void R_DrawCross(vec3_t origin)
+static void R_DrawCross(vec3_t origin, vec3_t color)
 {
 	static const float line_length = 8;
 	static const float shift_amount = 16;
@@ -1791,7 +1807,7 @@ static void R_DrawCross(vec3_t origin)
 	glMatrixMode(GL_MODELVIEW);
 	glPushMatrix();
 	glTranslatef(origin[0], origin[1], origin[2]);
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor3f(color[0], color[1], color[2]);
 	glCullFace(GL_FRONT);
 	glPolygonMode(GL_BACK, GL_LINE);
 	glLineWidth(1.0);
@@ -1834,7 +1850,7 @@ static void R_DrawCross(vec3_t origin)
 	glMatrixMode(GL_MODELVIEW);
 }
 
-static void R_DrawBbox(vec3_t origin, vec3_t mins, vec3_t maxs)
+static void R_DrawBbox(vec3_t origin, vec3_t mins, vec3_t maxs, vec3_t color)
 {
 	int i, j, k;
 	int d2, d3;
@@ -1844,7 +1860,7 @@ static void R_DrawBbox(vec3_t origin, vec3_t mins, vec3_t maxs)
 	VectorAdd(origin, mins, wmins);
 	VectorAdd(origin, maxs, wmaxs);
 
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor3f(color[0], color[1], color[2]);
 
 	glCullFace(GL_FRONT);
 	glPolygonMode(GL_BACK, GL_LINE);
@@ -1890,6 +1906,7 @@ static void R_DrawBbox(vec3_t origin, vec3_t mins, vec3_t maxs)
 
 void R_DrawEntBbox(entity_t *ent)
 {
+	vec3_t color = {1, 1, 1};
 	float *origin;
 	frame_range_t *range;
 	id1_bbox_t *bbox_info;
@@ -1911,11 +1928,13 @@ void R_DrawEntBbox(entity_t *ent)
 			else
 				origin = ent->msg_origins[0];
 
+			if (cl_bbox.value < 2)
+				VectorCopy(bbox_colors[bbox_info->bbox_cat], color);
 			if (VectorLength(bbox_info->mins) < 1e-2
 					&& VectorLength(bbox_info->maxs) < 1e-2)
-				R_DrawCross(origin);
+				R_DrawCross(origin, color);
 			else
-				R_DrawBbox(origin, bbox_info->mins, bbox_info->maxs);
+				R_DrawBbox(origin, bbox_info->mins, bbox_info->maxs, color);
 		}
 	}
 }

--- a/trunk/menu.c
+++ b/trunk/menu.c
@@ -4384,7 +4384,10 @@ void M_View_Draw (void)
 	glColor3ubv(color_white);
 
 	M_Print_GetPoint(16, 144, &lx, &ly, "   Show bounding boxes", view_cursor == 14);
-	M_DrawCheckbox(220, 144, cl_bbox.value);
+	M_Print(220, 144, cl_bbox.value == CL_BBOX_MODE_ON
+						? "on" : cl_bbox.value == CL_BBOX_MODE_DEMO
+						? "demo only" : cl_bbox.value == CL_BBOX_MODE_LIVE
+						? "live only" : "off");
 
 	M_Print_GetPoint(16, 152, &lx, &ly, "      Fullbright skins", view_cursor == 15);
 	M_Print(220, 152, !r_fullbrightskins.value ? "off" : r_fullbrightskins.value == 2 ? "players + monsters" : "players");
@@ -4549,7 +4552,7 @@ void M_View_Key (int k)
 			break;
 
 		case 14:
-			Cvar_SetValue(&cl_bbox, !cl_bbox.value);
+			Cvar_SetValue(&cl_bbox, ((int)cl_bbox.value + 1) % NUM_BBOX_MODE);
 			break;
 
 		case 15:


### PR DESCRIPTION
An assortment of cl_bbox changes

- Show point entities (grenades, rockets, spikes, etc) as stars.
- Coloured bboxes, toggle-able with `cl_bboxcolors`.
- bbox toggle in the demo ui.
- BBoxes enable-able independently for demo playback and live play.

Each of these items has (roughly) its own commit.

![image](https://github.com/user-attachments/assets/2b48450b-b620-4055-9d21-7d4f0d89279d)
