### PR TITLE
Single frame skip

### DIFF
--- a/docs/pages/cvars-commands.md
+++ b/docs/pages/cvars-commands.md
@@ -1175,6 +1175,8 @@ Available usage modes (example values):
 - `demoseek 12` will seek to the time 0:12
 - `demoseek +3` will seek forward 3 seconds from the actual position
 - `demoseek -5` will seek back 5 seconds from the actual position
+- `demoseek +f` will seek forward one frame.
+- `demoseek -f` will seek back one frame.
 
 ##### `toggleparticles`
 

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -38,6 +38,8 @@ ghost_info_t* demo_info = NULL;
 dseek_info_t demo_seek_info;
 qboolean demo_seek_info_available;
 static double seek_time;
+static long last_read_offset = 0;
+static qboolean seek_frame;
 static qboolean seek_backwards, seek_was_backwards;
 static dzip_context_t dzCtx;
 static qboolean	dz_playback = false;
@@ -186,6 +188,7 @@ static void
 EndSeek (void)
 {
 	seek_time = -1.0;
+	seek_frame = false;
 
 	if (seek_was_backwards)
 	{
@@ -223,10 +226,18 @@ int CL_GetMessage (void)
 	{
 		if (seek_time >= 0 && seek_backwards && cl.mtime[0] < seek_time)
 		{
-			// If we are seeking backwards and just passed the target time, go
-			// forwards for another frame.  This means the frame we settle on is
-			// always the one immediately after (or equal to) the target time.
-			seek_backwards = false;
+			if (seek_frame)
+			{
+				seek_time = cl.mtime[0];
+				seek_frame = false;
+			}
+			else
+			{
+				// If we are seeking backwards and just passed the target time, go
+				// forwards for another frame.	This means the frame we settle on is
+				// always the one immediately after (or equal to) the target time.
+				seek_backwards = false;
+			}
 		}
 
 		backwards = CL_DemoRewind();
@@ -268,7 +279,7 @@ int CL_GetMessage (void)
 			if (!backwards)
 			{
 				// joe: fill in the stack of frames' positions
-				PushFrameposEntry (ftell(cls.demofile));
+				PushFrameposEntry (last_read_offset);
 			}
 			else
 			{
@@ -284,6 +295,7 @@ int CL_GetMessage (void)
 		}
 
 		// get the next message
+		last_read_offset = ftell(cls.demofile);
 		fread (&net_message.cursize, 4, 1, cls.demofile);
 		VectorCopy (cl.mviewangles[0], cl.mviewangles[1]);
 		for (i = 0 ; i < 3 ; i++)
@@ -873,7 +885,14 @@ void CL_DemoSeek_f (void)
 	}
 
 	time_str = Cmd_Argv(1);
-	if (time_str[0] == '+' || time_str[0] == '-')
+	if (strcasecmp(time_str, "+f") == 0)
+		seek_time = cl.mtime[0] + 1e-3;
+	else if (strcasecmp(time_str, "-f") == 0)
+	{
+		seek_time = cl.mtime[0];
+		seek_frame = true;
+	}
+	else if (time_str[0] == '+' || time_str[0] == '-')
 		seek_time = cl.mtime[0] + atof(time_str);
 	else
 		seek_time = atof(time_str);
@@ -881,7 +900,7 @@ void CL_DemoSeek_f (void)
 	if (seek_time < 0.)
 		seek_time = 0.;
 
-	seek_was_backwards = seek_backwards = (seek_time < cl.mtime[0]);
+	seek_was_backwards = seek_backwards = (seek_time <= cl.mtime[0]);
 }
 
 /*

--- a/trunk/cl_demo.c
+++ b/trunk/cl_demo.c
@@ -39,8 +39,7 @@ dseek_info_t demo_seek_info;
 qboolean demo_seek_info_available;
 static double seek_time;
 static long last_read_offset = 0;
-static qboolean seek_frame;
-static qboolean seek_backwards, seek_was_backwards;
+static qboolean seek_backwards, seek_was_backwards, seek_frame;
 static dzip_context_t dzCtx;
 static qboolean	dz_playback = false;
 qboolean	dz_unpacking = false;
@@ -228,6 +227,9 @@ int CL_GetMessage (void)
 		{
 			if (seek_frame)
 			{
+				// If we are skipping back a frame, we must find the last
+				// message from two frames previous, then we seek forward to the
+				// first message from one frame previous.
 				seek_time = cl.mtime[0];
 				seek_frame = false;
 			}


### PR DESCRIPTION
This PR extends the `demoseek` command with arguments for skipping forward and back a single frame when playing a demo.  Bind `demoseek -f` and `demoseek +f` to see how it works.

Skipping forward is easy:  Do a normal seek forward with some small positive  time.  The existing seeking logic then loads messages until the first message that has a time greater than the start time.

Seeking backwards is more difficult.  Doing a seek with a small negative time goes backward until we find a message with a time less than the start time, then it seeks forward until the time increases again.  Hence `demoseek -0.0001` is a no-op.  This behaviour means that repeatedly seeking to the same time (or times very close to each other) does not bounce between neighbouring frames, which can happen when slowly dragging the demo ui slider.  But it does make implementing backward frame skipping slightly more awkward.

To get around this problem, this PR introduces a new boolean flag `seek_frame` which is set to true when skipping backwards a single frame.  It has the effect of causing `CL_GetMessage` to seek back two frames, then forward one frame, giving a net shift of one frame backwards.