### PR TITLE
Q64 remaster support

### DIFF
--- a/trunk/bspfile.h
+++ b/trunk/bspfile.h
@@ -58,6 +58,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 /* BSP2 support. 32bits instead of shorts for everything (bboxes use floats) */
 #define BSP2VERSION_BSP2 (('B' << 0) | ('S' << 8) | ('P' << 16) | ('2'<<24)) 
 
+// Quake64 (Nintendo 64 Remaster) format
+#define BSPVERSION_QUAKE64 (('Q' << 24) | ('6' << 16) | ('4' << 8) | ' ')
+
 typedef struct
 {
 	int		fileofs, filelen;
@@ -109,6 +112,15 @@ typedef struct miptex_s
 	unsigned	width, height;
 	unsigned	offsets[MIPLEVELS];		// four mip maps stored
 } miptex_t;
+
+// Quake64 (Nintendo 64 Remaster) miptex structure
+typedef struct miptex64_s
+{
+	char		name[16];
+	unsigned	width, height;
+	unsigned	shift;
+	unsigned	offsets[MIPLEVELS];		// four mip maps stored
+} miptex64_t;
 
 
 typedef struct

--- a/trunk/gl_model.h
+++ b/trunk/gl_model.h
@@ -74,6 +74,7 @@ typedef struct texture_s
 {
 	char		name[16];
 	unsigned	width, height;
+	unsigned	shift;					// texture shift for Q64 (Nintendo 64 Remaster)
 	int			gl_texturenum;
 	int			fb_texturenum;			// index of fullbright mask or 0
 	int			warp_texturenum;
@@ -588,6 +589,7 @@ typedef struct model_s
 	byte		*lightdata;
 	char		*entities;
 
+	int			bspversion;
 	qboolean	isworldmodel;
 	qboolean	haslitwater;
 

--- a/trunk/gl_rsurf.c
+++ b/trunk/gl_rsurf.c
@@ -2338,6 +2338,13 @@ void BuildSurfaceDisplayList (msurface_t *fa)
 		poly->verts[i][3] = s;
 		poly->verts[i][4] = t;
 
+		// Q64 RERELEASE texture shift
+		if (fa->texinfo->texture->shift > 0)
+		{
+			poly->verts[i][3] /= ( 2 * fa->texinfo->texture->shift);
+			poly->verts[i][4] /= ( 2 * fa->texinfo->texture->shift);
+		}
+
 		// lightmap texture coordinates
 		s = DotProduct(vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3];
 		s -= fa->texturemins[0];

--- a/trunk/glquake.h
+++ b/trunk/glquake.h
@@ -400,6 +400,7 @@ int R_SetSky (char *skyname);
 void Sky_NewMap(void);
 void R_DrawSky(void);
 void R_InitSky(texture_t *mt);		// called at level load
+void R_InitSkyQ64(texture_t *mt);
 void R_UpdateWarpTextures(void);
 extern int gl_warpimagesize;
 

--- a/trunk/host.c
+++ b/trunk/host.c
@@ -1065,8 +1065,7 @@ void Host_Init (quakeparms_t *parms)
 	        Neh_Init ();
 #endif
 
-	if (machine)
-		LOC_Init(); // for the machinegames mission pack from the 2021 rerelease
+	LOC_Init(); // for the machinegames mission pack from the 2021 rerelease (and the Nintendo 64 remaster)
 
 	Hunk_AllocName (0, "-HOST_HUNKLEVEL-");
 	host_hunklevel = Hunk_LowMark ();


### PR DESCRIPTION
The 2021 remaster has a Q64 addon that basically provides the Nintendo 64 release of Quake as playable .pak file. vkQuake and Quakespasm added support for this in https://github.com/Novum/vkQuake/pull/356, https://github.com/sezero/quakespasm/commit/b796e366db8b71094336270096885b38ab08b337 and https://github.com/sezero/quakespasm/commit/0fc09fd95d57b56e05ee859a15a96245ba61084c so I just adapted this for JoeQuake. Seems to work quite well.

Note that I made the localization init unconditional now (before it was only loaded when passing `-machine`), since Q64 also relies on the localization text replacement. Let me know if you would like to handle this differently.