### PR TITLE
Fixes to demo browser/bhop practice issues

### DIFF
--- a/trunk/bhop/practice.c
+++ b/trunk/bhop/practice.c
@@ -1,4 +1,5 @@
 /*
+ * p_su
  * Bunnyhopping statistics and practice module
  * Prepares display for various graphics showcasing how well the user is
  * bunnyhopping. 
@@ -512,18 +513,6 @@ void Bhop_GatherData(void)
 }
 
 /*
- * print a summary to console
- */
-void Bhop_PrintSummary(void)
-{
-    bhop_summary_t summary = Bhop_GetSummary(bhop_history, Bhop_Len(bhop_history), false);
-    Con_Printf(
-        "overall bhop summary:\n+forward ground accuracy: %3.1f%%\n+forward overall accuracy: %3.1f%%\nstrafe accuracy: %3.1f\n%%",
-        summary.fwd_on_ground_percent, summary.fwd_percent, summary.strafe_percent
-    );
-}
-
-/*
  * speed up drawing of the key arrays by detecting continuous chunks
  */
 void Bhop_DrawKeyContinuous(int *frames, int window, int x, int y, int height)
@@ -812,8 +801,6 @@ void BHOP_Stop (void)
     Bhop_CullHistory(bhop_history, 0);
     bhop_history = NULL;
     if (bhop_summary) {
-        if (show_bhop_stats.value > 0)
-            Bhop_PrintSummary();
         if (bhop_summary->speeds)
             free(bhop_summary->speeds);
         if (bhop_summary->keys) {
@@ -960,6 +947,12 @@ void SCR_DrawBHOPIntermission(void)
         histlen = Bhop_Len(bhop_history);
         bhop_summary = malloc(sizeof(bhop_summary_t));
         *bhop_summary = Bhop_GetSummary(bhop_history, histlen, true);
+    }
+
+    if (!bhop_summary->keys) {
+        free(bhop_summary);
+        bhop_summary = NULL;
+        return;
     }
 
     if ((int)show_bhop_stats.value & BHOP_AVG_SPEED) {

--- a/trunk/qcurses/browser.c
+++ b/trunk/qcurses/browser.c
@@ -988,11 +988,21 @@ void M_Demos_DisplayBrowser (int cols, int rows, int start_col, int start_row) {
             blinkstr(0x0d), 
             false
         );
+        /* This gives a full highlight around the whole box
+         *Draw_AlphaFillRGB(
+         *    start_col * 8,
+         *    start_row * 8,
+         *    map_box->cols * 8 / Sbar_GetScaleAmount(),
+         *    map_box->rows * 8 / Sbar_GetScaleAmount(),
+         *    BROWSER_HIGHLIGHT_COLOR,
+         *    0.15
+         *);
+         */
         Draw_AlphaFillRGB(
             start_col * 8,
-            start_row * 8,
+            (start_row + 2 + columns[COL_MAP]->list.cursor - columns[COL_MAP]->list.window_start) * 8,
             map_box->cols * 8 / Sbar_GetScaleAmount(),
-            map_box->rows * 8 / Sbar_GetScaleAmount(),
+            8 / Sbar_GetScaleAmount(),
             BROWSER_HIGHLIGHT_COLOR,
             0.15
         );
@@ -1017,11 +1027,21 @@ void M_Demos_DisplayBrowser (int cols, int rows, int start_col, int start_row) {
                 blinkstr(0x0d),
                 false
             );
+            /* This gives a full highlight around the whole box
+             *Draw_AlphaFillRGB(
+             *    (start_col + map_box->cols) * 8,
+             *    start_row * 8,
+             *    skill_box->cols * 8 / Sbar_GetScaleAmount(),
+             *    skill_box->rows * 8 / Sbar_GetScaleAmount(),
+             *    BROWSER_HIGHLIGHT_COLOR,
+             *    0.15
+             *);
+             */
             Draw_AlphaFillRGB(
                 (start_col + map_box->cols) * 8,
-                start_row * 8,
+                (start_row + 2 + columns[COL_TYPE]->list.cursor - columns[COL_TYPE]->list.window_start) * 8,
                 skill_box->cols * 8 / Sbar_GetScaleAmount(),
-                skill_box->rows * 8 / Sbar_GetScaleAmount(),
+                8 / Sbar_GetScaleAmount(),
                 BROWSER_HIGHLIGHT_COLOR,
                 0.15
             );
@@ -1052,11 +1072,21 @@ void M_Demos_DisplayBrowser (int cols, int rows, int start_col, int start_row) {
                 blinkstr(0x0d),
                 false
             );
+            /* This gives a full highlight around the whole box
+             *Draw_AlphaFillRGB( 
+             *    (start_col + map_box->cols + skill_box->cols) * 8,
+             *    start_row * 8,
+             *    time_box->cols * 8 / Sbar_GetScaleAmount(),
+             *    time_box->rows * 8 / Sbar_GetScaleAmount(),
+             *    BROWSER_HIGHLIGHT_COLOR,
+             *    0.15
+             *);
+             */
             Draw_AlphaFillRGB(
                 (start_col + map_box->cols + skill_box->cols) * 8,
-                start_row * 8,
+                (start_row + 2 + columns[COL_RECORD]->list.cursor - columns[COL_RECORD]->list.window_start) * 8,
                 time_box->cols * 8 / Sbar_GetScaleAmount(),
-                time_box->rows * 8 / Sbar_GetScaleAmount(),
+                8 / Sbar_GetScaleAmount(),
                 BROWSER_HIGHLIGHT_COLOR,
                 0.15
             );

--- a/trunk/qcurses/browser.c
+++ b/trunk/qcurses/browser.c
@@ -218,6 +218,7 @@ void M_Demos_KeyHandle_Browser (int k) {
         if (k == 'k' && !demo_browser_vim.value)
             break;
     case K_UPARROW:
+    case K_MWHEELUP:
         if (browser_col <= COL_RECORD){
             qcurses_list_move_cursor(mapslist, -distance);
             Browser_UpdateFurtherColumns(browser_col);
@@ -225,10 +226,6 @@ void M_Demos_KeyHandle_Browser (int k) {
         } else if (browser_col == COL_COMMENT_LOADED) {
             comment_page = max(0, comment_page - distance);
         }
-        break;
-    case K_MWHEELUP:
-        if (mapslist->window_start > 0)
-            mapslist->window_start = max(mapslist->window_start - scroll_lines, 0);
         break;
     case 'd':
         if (!keydown[K_CTRL] || !demo_browser_vim.value)
@@ -240,6 +237,7 @@ void M_Demos_KeyHandle_Browser (int k) {
         if (k == 'j' && !demo_browser_vim.value)
             break;
     case K_DOWNARROW:
+    case K_MWHEELDOWN:
         if (browser_col <= COL_RECORD) {
             qcurses_list_move_cursor(mapslist, distance);
             Browser_UpdateFurtherColumns(browser_col);
@@ -247,10 +245,6 @@ void M_Demos_KeyHandle_Browser (int k) {
         } else if (browser_col == COL_COMMENT_LOADED) {
             comment_page += distance;
         }
-        break;
-    case K_MWHEELDOWN:
-        if (mapslist->window_start + mapslist->places < mapslist->len)
-            mapslist->window_start = min(mapslist->window_start + scroll_lines, mapslist->len - mapslist->places);
         break;
     case 'l':
         if (!demo_browser_vim.value)

--- a/trunk/qcurses/browser_local.c
+++ b/trunk/qcurses/browser_local.c
@@ -479,15 +479,12 @@ void M_Demos_KeyHandle_Local (int k, int max_lines) {
         distance = keydown[K_HOME] ? num_files : max_lines - 1;
     case K_UPARROW:
     case 'k':
+    case K_MWHEELUP:
         if (k == 'k' && !demo_browser_vim.value)
             break;
         distance = (demlist->list.cursor == 0) ? num_files : -distance;
         qcurses_list_move_cursor((qcurses_list_t*)demlist, distance);
         S_LocalSound("misc/menu1.wav");
-        break;
-    case K_MWHEELUP:
-        if (demlist->list.window_start > 0)
-            demlist->list.window_start = max(demlist->list.window_start - scroll_lines, 0);
         break;
     case 'd':
         if (!keydown[K_CTRL] || !demo_browser_vim.value)
@@ -497,15 +494,12 @@ void M_Demos_KeyHandle_Local (int k, int max_lines) {
         distance = keydown[K_END] ? num_files : max_lines - 1;
     case K_DOWNARROW:
     case 'j':
+    case K_MWHEELDOWN:
         if (k == 'j' && !demo_browser_vim.value)
             break;
         distance = (demlist->list.cursor == num_files - 1) ? -num_files : distance;
         qcurses_list_move_cursor((qcurses_list_t*)demlist, distance);
         S_LocalSound("misc/menu1.wav");
-        break;
-    case K_MWHEELDOWN:
-        if (demlist->list.window_start + max_lines < num_files)
-            demlist->list.window_start = min(demlist->list.window_start + scroll_lines, num_files - max_lines);
         break;
     case 'f':
         if (keydown[K_CTRL])

--- a/trunk/qcurses/browser_local.c
+++ b/trunk/qcurses/browser_local.c
@@ -224,8 +224,17 @@ void M_Demos_DisplayLocal (int cols, int rows, int start_col, int start_row) {
         }
     }
 
-    if (demlist)
+    if (demlist) {
+        Draw_AlphaFillRGB(
+            start_col * 8,
+            (start_row + 2 + demlist->list.cursor - demlist->list.window_start) * 8,
+            cols * 8 / Sbar_GetScaleAmount(),
+            8 / Sbar_GetScaleAmount(),
+            BROWSER_HIGHLIGHT_COLOR,
+            0.15
+        );
         qcurses_print(name_box, 0, 2 + demlist->list.cursor - demlist->list.window_start, blinkstr(0x0d), false);
+    }
 
     M_Demos_HelpBox (help_box, TAB_LOCAL_DEMOS, search_term, search_input);
 

--- a/trunk/qcurses/browser_local.h
+++ b/trunk/qcurses/browser_local.h
@@ -28,6 +28,23 @@ typedef struct thread_data_s {
     uint32_t localread_count;
 } thread_data_t;
 
+typedef struct thread_list_s {
+    thread_data_t * data;
+    struct thread_list_s *prev;
+    struct thread_list_s *next;
+} thread_list_t;
+
+typedef struct thread_queue_s {
+    thread_list_t * first;
+    thread_list_t * last;
+} thread_queue_t;
+
+thread_queue_t * create_queue();
+void enqueue(thread_queue_t * queue, thread_data_t * data);
+int len_queue(thread_queue_t * queue);
+thread_data_t * dequeue(thread_queue_t * queue);
+void destroy_queue(thread_queue_t * queue);
+
 enum local_columns {
     LOC_MAP,
     LOC_SIZE,


### PR DESCRIPTION
Fixes the following issues:
 - mousewheel will no longer crash the browser when things go off-screen
 - the window highlight now focuses on the selected line in addition to being contained to the selected section of the window
 - a primitive 'threadpool' (actually thread counting) implementation means directories with thousands of demos will no longer crash the browser - it will simply sequentially run the summary creation in a couple of threads. To facilitate queuing a simple queue implementation for the thread starting data has been added.
 - crash when stopping demo in intermission with bhop stats